### PR TITLE
Add Caddyfile with environment placeholders

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,26 @@
+{$ADDR} {
+  {$AUTO_HTTPS}
+  encode zstd gzip
+
+  @static path_regexp static ^/(assets|static|favicon\.ico|robots\.txt|manifest\.json)
+
+  handle_path /api/* {
+    reverse_proxy api:8000
+  }
+
+  route {
+    root * /srv
+    try_files {path} /index.html
+    file_server
+  }
+
+  header {
+    {$HSTS_LINE}  # blank in dev; set HSTS only in prod
+    X-Content-Type-Options "nosniff"
+    X-Frame-Options "DENY"
+    Referrer-Policy "no-referrer-when-downgrade"
+    Permissions-Policy "geolocation=(), microphone=(), camera=()"
+  }
+
+  {$TLS_DIRECTIVE} # blank in dev; `tls ${EMAIL}` in prod
+}


### PR DESCRIPTION
This PR adds a Caddyfile with environment placeholders and conditional TLS/HSTS lines. The Caddyfile reads variables from the environment to configure the address, HTTPS/TLS, and HSTS policies for development versus production. This allows the containerised loan calculator to be deployed easily in both local (HTTP) and production (HTTPS) environments without manual edits.