### PR TITLE
chore: add .env.example with dev/prod toggles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Example environment file for loan calculator
+
+# Domain and email used by Caddy for Let's Encrypt (production)
+DOMAIN=example.com
+EMAIL=admin@example.com
+
+# Address and scheme used by Caddy (development vs production)
+# In dev, use http://localhost to disable TLS and HSTS; in prod use your domain
+ADDR=http://localhost
+
+# Caddy toggle for automatic HTTPS (use 'auto_https off' in dev; blank in prod)
+AUTO_HTTPS=auto_https off
+
+# TLS directive (blank in dev; 'tls ${EMAIL}' in prod)
+TLS_DIRECTIVE=
+
+# HSTS line (set only in prod; blank in dev)
+HSTS_LINE=
+
+# Compose project name for docker-compose
+COMPOSE_PROJECT_NAME=loancalc


### PR DESCRIPTION
This PR introduces a `.env.example` file demonstrating the environment variables needed to run the loan calculator in development and production.

It includes placeholders for:

- `DOMAIN` and `EMAIL` used by Caddy for Let's Encrypt (prod)
- `ADDR` to control HTTP vs HTTPS binding
- `AUTO_HTTPS` toggle (`auto_https off` in dev, blank in prod)
- `TLS_DIRECTIVE` (blank in dev; `tls ${EMAIL}` in prod)
- `HSTS_LINE` (blank in dev; HSTS header in prod)
- `COMPOSE_PROJECT_NAME` used by docker-compose

This file provides clear examples for local testing versus deployment to a secure domain.