### PR TITLE
chore: add docker-compose.yml for caddy, web, api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+services:
+  caddy:
+    image: caddy:2.8
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    env_file: .env
+    environment:
+      - DOMAIN=${DOMAIN}
+      - EMAIL=${EMAIL}
+    volumes:
+      - caddy_data:/data
+      - caddy_config:/config
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - webdist:/srv:ro
+    depends_on:
+      - web
+      - api
+
+  web:
+    build: ./web
+    restart: unless-stopped
+    volumes:
+      - webdist:/site:ro
+
+  api:
+    build: ./api
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:
+  webdist:


### PR DESCRIPTION
This PR introduces a Docker Compose configuration for the loan-calculator.

Highlights:

- Defines a **caddy** service pulling the Caddy 2.8 image, exposing ports 80/443, loading environment variables from `.env`, and mounting the Caddyfile and volumes. The service depends on the `api` and `web` services.
- Adds a **web** service that builds the static site from `./web` and mounts the `webdist` volume for sharing static assets with Caddy.
- Adds an **api** service that builds the FastAPI backend from `./api`.
- Creates named volumes (`caddy_data`, `caddy_config`, `webdist`) for persistent TLS data, config, and static files.

This compose file allows you to spin up the entire stack with `docker compose up -d`.