### PR TITLE
Restrict CORS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # loan-calculator-trial
+
+## CORS configuration
+
+The API exposes configuration for cross-origin requests via the
+`ALLOWED_ORIGINS` environment variable. Set this to a comma-separated list of
+origins that are permitted to access the API (for example,
+`ALLOWED_ORIGINS="https://example.com,http://localhost:8080"`).
+
+If `ALLOWED_ORIGINS` is not provided, cross-origin requests will be blocked by
+default to reduce the risk of malicious sites interacting with the service.
+

--- a/api/app.py
+++ b/api/app.py
@@ -11,10 +11,17 @@ import os
 
 
 app = FastAPI(title="Dealer Quote API", version="0.1.0")
+
+# Configure CORS to only allow specific origins instead of allowing all requests.
+# Origins can be supplied via the ALLOWED_ORIGINS environment variable as a
+# comma-separated list (e.g. "https://example.com,http://localhost:8080").
+allowed_origins = [
+    o.strip() for o in os.getenv("ALLOWED_ORIGINS", "").split(",") if o.strip()
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["*"],
+    allow_origins=allowed_origins,
+    allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
## Summary
- limit API cross-origin requests to configurable list of allowed origins
- document `ALLOWED_ORIGINS` environment variable

## Testing
- `python -m py_compile api/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68acaf92f3a08332b5250a599e5df0c0