### PR TITLE
feat: capture affiliate params on frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,16 @@ origins that are permitted to access the API (for example,
 If `ALLOWED_ORIGINS` is not provided, cross-origin requests will be blocked by
 default to reduce the risk of malicious sites interacting with the service.
 
+## API endpoints
+
+- `GET /api/health` – service health check.
+- `POST /api/quote` – compute financing details.
+- `POST /api/leads` – store submitted leads.
+- `POST /api/track` – log affiliate clicks with a timestamp.
+
+## Affiliate tracking
+
+The frontend captures `aff` and common UTM query parameters. When an affiliate ID
+is present it is sent to the backend `/api/track` endpoint and stored in
+`localStorage` for later use.
+

--- a/api/app.py
+++ b/api/app.py
@@ -90,3 +90,26 @@ def create_lead(lead: LeadReq):
         json.dump(data, f)
     return LeadResp(message="Lead received")
 
+
+class TrackReq(BaseModel):
+    affiliate: str
+
+
+class TrackResp(BaseModel):
+    message: str
+
+
+@app.post("/api/track", response_model=TrackResp)
+def track_click(track: TrackReq):
+    track_file = "tracks.json"
+    entry = {"affiliate": track.affiliate, "timestamp": datetime.utcnow().isoformat()}
+    if os.path.exists(track_file):
+        with open(track_file, "r") as f:
+            data = json.load(f)
+    else:
+        data = []
+    data.append(entry)
+    with open(track_file, "w") as f:
+        json.dump(data, f)
+    return TrackResp(message="Tracked")
+

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -77,6 +77,21 @@
   </div>
 
 <script>
+const params = new URLSearchParams(window.location.search);
+const aff = params.get('aff');
+['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'].forEach(k => {
+  const v = params.get(k);
+  if (v) localStorage.setItem(k, v);
+});
+if (aff) {
+  localStorage.setItem('affiliate', aff);
+  fetch('/api/track', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ affiliate: aff })
+  });
+}
+
 const presets = {
   auto: { apr: 6.9, term: 60 },
   rv:   { apr: 8.9, term: 120 },


### PR DESCRIPTION
## Summary
- capture affiliate and UTM parameters on the frontend and forward them to `/api/track`
- document new affiliate tracking behavior in the README

## Testing
- `ruff check api/app.py`
- `yamllint docker-compose.yml` *(command not found)*
- `markdownlint README.md` *(command not found)*
- `uvicorn api.app:app --port 8000` *(command not found)*
- `python - <<'PY' ...` *(ModuleNotFoundError: fastapi)*
- `curl -sSf http://localhost:8000/api/health` *(Failed to connect: Couldn't connect to server)*
- `python -m http.server 8001` and `curl -I http://localhost:8001/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68acb38509bc83329d3716acad4be8d5