### PR TITLE
fix: animate cost breakdown pie chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fast, responsive loan payment calculator for autos, RVs, motorcycles, and jet sk
 
 ## Features
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
-- 📊 **Animated cost breakdown**: pie chart updates smoothly with principal vs interest.
+- 📊 **Animated cost breakdown**: 3D pie chart with a bouncy update effect highlighting principal vs interest.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Fast, responsive loan payment calculator for autos, RVs, motorcycles, and jet sk
 
 ## Features
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
+- 📊 **Animated cost breakdown**: pie chart updates smoothly with principal vs interest.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -19,25 +19,37 @@ function pmnt(principal, aprPct, n) {
   return principal * (r * Math.pow(1+r, n)) / (Math.pow(1+r, n) - 1);
 }
 
-function fmt(n){ 
-  return n.toLocaleString(undefined, {style:'currency', currency:'USD'}) 
+function fmt(n){
+  return n.toLocaleString(undefined, {style:'currency', currency:'USD'})
 }
 
+let costChart;
+
 function updateChart(principal, interest) {
-  const total = principal + interest;
-  if (total === 0) return;
-  
-  const principalPercent = (principal / total) * 100;
-  const interestPercent = (interest / total) * 100;
-  
-  const principalSlice = document.getElementById('principal-slice');
-  const interestSlice = document.getElementById('interest-slice');
-  
-  const circumference = 2 * Math.PI * 37.5;
-  
-  principalSlice.style.strokeDasharray = `${(principalPercent / 100) * circumference} ${circumference}`;
-  interestSlice.style.strokeDasharray = `${(interestPercent / 100) * circumference} ${circumference}`;
-  interestSlice.style.strokeDashoffset = `-${(principalPercent / 100) * circumference}`;
+  if (principal + interest === 0) return;
+
+  const ctx = document.getElementById('cost-chart').getContext('2d');
+  if (!costChart) {
+    costChart = new Chart(ctx, {
+      type: 'pie',
+      data: {
+        labels: ['Total loan amount paid', 'Total interest paid'],
+        datasets: [{
+          data: [principal, interest],
+          backgroundColor: ['#d4af37', '#10b981'],
+          borderWidth: 0
+        }]
+      },
+      options: {
+        animation: {
+          duration: 500
+        }
+      }
+    });
+  } else {
+    costChart.data.datasets[0].data = [principal, interest];
+    costChart.update();
+  }
 }
 
 function calc(){

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -28,7 +28,8 @@ let costChart;
 function updateChart(principal, interest) {
   if (principal + interest === 0) return;
 
-  const ctx = document.getElementById('cost-chart').getContext('2d');
+  const canvas = document.getElementById('cost-chart');
+  const ctx = canvas.getContext('2d');
   if (!costChart) {
     costChart = new Chart(ctx, {
       type: 'pie',
@@ -42,14 +43,23 @@ function updateChart(principal, interest) {
       },
       options: {
         animation: {
-          duration: 500
+          duration: 1000,
+          easing: 'easeOutElastic',
+          animateRotate: true,
+          animateScale: true
         }
       }
     });
   } else {
     costChart.data.datasets[0].data = [principal, interest];
+    costChart.options.animation.easing = 'easeOutElastic';
+    costChart.options.animation.duration = 1000;
     costChart.update();
   }
+
+  canvas.classList.remove('bounce');
+  void canvas.offsetWidth;
+  canvas.classList.add('bounce');
 }
 
 function calc(){

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -109,10 +109,7 @@
         <div class="chart-section">
           <h3 class="chart-title">Cost Breakdown</h3>
           <div class="pie-chart">
-            <svg viewBox="0 0 100 100">
-              <circle class="slice" cx="50" cy="50" r="37.5" stroke="#d4af37" stroke-dasharray="0 235.5" id="principal-slice"/>
-              <circle class="slice" cx="50" cy="50" r="37.5" stroke="#10b981" stroke-dasharray="0 0" id="interest-slice"/>
-            </svg>
+            <canvas id="cost-chart"></canvas>
           </div>
           <div class="chart-legend">
             <div class="legend-item">
@@ -217,6 +214,7 @@
     </footer>
   </div>
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/web/dist/style.css
+++ b/web/dist/style.css
@@ -339,6 +339,24 @@ body {
 .pie-chart canvas {
   width: 100%;
   height: 100%;
+  transform: perspective(800px) rotateX(20deg);
+  transform-origin: center;
+  transition: transform 0.6s;
+  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.15);
+  border-radius: 50%;
+}
+
+.pie-chart canvas.bounce {
+  animation: chart-bounce 1s ease;
+}
+
+@keyframes chart-bounce {
+  0%, 100% {
+    transform: perspective(800px) rotateX(20deg) scale(1);
+  }
+  50% {
+    transform: perspective(800px) rotateX(20deg) scale(1.05);
+  }
 }
 
 .chart-legend {

--- a/web/dist/style.css
+++ b/web/dist/style.css
@@ -336,16 +336,9 @@ body {
   position: relative;
 }
 
-.pie-chart svg {
+.pie-chart canvas {
   width: 100%;
   height: 100%;
-  transform: rotate(-90deg);
-}
-
-.pie-chart .slice {
-  fill: none;
-  stroke-width: 75;
-  stroke-linecap: round;
 }
 
 .chart-legend {


### PR DESCRIPTION
## Summary
- replace broken cost breakdown SVG with Chart.js pie chart
- load Chart.js from CDN and style canvas container
- document the animated cost breakdown feature in README

## Testing
- `python -m py_compile api/app.py`
- `pip install flake8 yamllint` *(fails: 403 Forbidden)*
- `pip install pyyaml` *(fails: 403 Forbidden)*
- `npx markdownlint README.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad11acccd88332aa965567bae0a2e9