### PR TITLE
fix: remove cost chart afterimage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fast, responsive loan payment calculator for autos, RVs, motorcycles, and jet sk
 
 ## Features
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
-- 📊 **Animated cost breakdown**: 3D pie chart with a bouncy update effect highlighting principal vs interest.
+- 📊 **Cost breakdown chart**: smooth 3D pie chart with a CSS bounce effect highlighting principal vs interest.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -41,20 +41,11 @@ function updateChart(principal, interest) {
           borderWidth: 0
         }]
       },
-      options: {
-        animation: {
-          duration: 1000,
-          easing: 'easeOutElastic',
-          animateRotate: true,
-          animateScale: true
-        }
-      }
+      options: { animation: false }
     });
   } else {
     costChart.data.datasets[0].data = [principal, interest];
-    costChart.options.animation.easing = 'easeOutElastic';
-    costChart.options.animation.duration = 1000;
-    costChart.update();
+    costChart.update('none');
   }
 
   canvas.classList.remove('bounce');


### PR DESCRIPTION
## Summary
- eliminate Chart.js animation to prevent afterimage on cost breakdown pie chart
- document smoother CSS-only chart animation in README

## Testing
- `python -m py_compile api/app.py`
- `yamllint docker-compose.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint; Tunnel connection failed: 403 Forbidden)*
- `markdownlint README.md` *(fails: command not found)*
- `npm install -g markdownlint-cli` *(fails: 403 Forbidden - GET https://registry.npmjs.org/markdownlint-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68ad451622e883328c2589aa3111aa40