### PR TITLE
feat: add vehicle type presets to loan calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Base URL in dev: `http://localhost`
 - Modular static assets in `web/dist` (`index.html`, `style.css`, `app.js`)
 - Footer links to legal pages (`privacy.html`, `terms.html`)
 - The lead form (to be added) will auto-capture `affiliate`/UTM parameters from the page URL and submit them with the lead payload.
-- Calculator presets update APR and term per vehicle type.
+- Vehicle type dropdown (Auto, RV, Motorcycle, Jet Ski) updates APR and term presets.
 
 ## Environment variables
 

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -13,6 +13,26 @@ if (aff) {
   });
 }
 
+const presets = {
+  auto: { apr: 10, term: 5 },
+  rv: { apr: 8, term: 15 },
+  moto: { apr: 12, term: 5 },
+  ski: { apr: 9, term: 3 }
+};
+
+function applyPreset(type) {
+  const preset = presets[type];
+  if (preset) {
+    document.getElementById('apr').value = preset.apr;
+    document.getElementById('term').value = preset.term;
+    document.getElementById('years').checked = true;
+  }
+}
+
+document.getElementById('vehicle').addEventListener('change', (e) => {
+  applyPreset(e.target.value);
+});
+
 function pmnt(principal, aprPct, n) {
   const r = (aprPct/100)/12;
   if (r === 0) return principal / n;
@@ -136,6 +156,7 @@ function openLeadModal() {
   document.getElementById('lead-modal').classList.add('show');
   // Pre-fill price from calculator
   document.getElementById('lead-price').value = document.getElementById('price').value;
+  document.getElementById('lead-vehicle').value = document.getElementById('vehicle').value;
 }
 
 function closeLeadModal() {
@@ -223,4 +244,5 @@ document.getElementById('lead-btn').addEventListener('click', () => {
 document.getElementById('lead-form').addEventListener('submit', handleLeadSubmission);
 
 // Initialize with default values
+applyPreset(document.getElementById('vehicle').value);
 calc();

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -37,6 +37,16 @@
         </div>
         <div class="card-body">
           <div class="form-group">
+            <label for="vehicle">Vehicle type</label>
+            <select id="vehicle">
+              <option value="auto">Auto</option>
+              <option value="rv">RV</option>
+              <option value="moto">Motorcycle</option>
+              <option value="ski">Jet Ski</option>
+            </select>
+          </div>
+
+          <div class="form-group">
             <label for="price">Loan amount</label>
             <input id="price" type="number" value="10000" placeholder="Enter loan amount" />
           </div>

--- a/web/dist/style.css
+++ b/web/dist/style.css
@@ -100,7 +100,7 @@ body {
 .card-header h2 {
   font-size: 1.5rem;
   font-weight: 600;
-  color: var(--text-primary);
+  color: white;
   margin: 0;
 }
 


### PR DESCRIPTION
## Summary
- add vehicle type dropdown with presets for APR and term
- prefill lead form with selected vehicle type
- improve header contrast so loan calculator label is visible

## Testing
- `make lint` *(fails: yamllint: command not found)*
- `mdformat --check README.md docs` *(fails: mdformat: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4aeebb248332a6472ec00ee72b81