### PR TITLE
fix: improve pie chart rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast, responsive loan payment calculator for autos, RVs, motorcycles, and jet sk
 ## Features
 
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
-- 📊 **Cost breakdown chart**: smooth 3D pie chart with a CSS bounce effect highlighting principal vs interest.
+- 📊 **Cost breakdown chart**: smooth 3D pie chart with a CSS bounce effect highlighting principal vs interest, with the legend displayed outside the chart.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.

--- a/web/dist/app.js
+++ b/web/dist/app.js
@@ -41,7 +41,13 @@ function updateChart(principal, interest) {
           borderWidth: 0
         }]
       },
-      options: { animation: false }
+      options: {
+        animation: false,
+        maintainAspectRatio: false,
+        plugins: {
+          legend: { display: false }
+        }
+      }
     });
   } else {
     costChart.data.datasets[0].data = [principal, interest];


### PR DESCRIPTION
## Summary
- ensure pie chart renders correctly by disabling built-in legend
- allow custom legend outside chart by disabling aspect ratio maintenance
- document external legend in README

## Testing
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint (ProxyError 403 Forbidden))*
- `make lint` *(fails: yamllint: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad495235ac8332903c78f8db6da4f5