### PR TITLE
feat: polish cost breakdown chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jump‑start your next ride with a fast, responsive vehicle loan payment calcula
 ## Features
 
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
-- 📊 **Cost breakdown chart**: smooth 3D pie chart with a CSS bounce effect highlighting principal vs interest, with the legend displayed outside the chart.
+- 📊 **Cost breakdown chart**: enhanced 3D pie chart with gradient and shine plus a CSS bounce effect highlighting principal vs interest, with the legend displayed outside the chart.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -123,11 +123,11 @@
           </div>
           <div class="chart-legend">
             <div class="legend-item">
-              <div class="legend-color" style="background: #d4af37;"></div>
+              <div class="legend-color" style="background: linear-gradient(180deg, #93c5fd 0%, #1e3a8a 100%);"></div>
               <span>Total vehicle loan amount paid</span>
             </div>
             <div class="legend-item">
-              <div class="legend-color" style="background: #10b981;"></div>
+              <div class="legend-color" style="background: linear-gradient(180deg, #fdba74 0%, #c2410c 100%);"></div>
               <span>Total interest paid</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- enhance pie chart slices with gradients, shadows, and a shine overlay for a stronger 3D look
- switch to contrasting blue and orange color scheme that matches legend entries
- document upgraded cost breakdown chart in README

## Testing
- `node --check web/dist/app.js`
- `make lint` *(fails: yamllint: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4fe8c9f48332ac16b6610a517ad7