### PR TITLE
chore: parameterize Caddy domain and email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,9 @@
 # Example environment file for vehicle loan calculator
 
-# Domain and email used by Caddy for Let's Encrypt (production)
+# Domain and email used by Caddy for Let's Encrypt
 DOMAIN=example.com
 EMAIL=admin@example.com
 
-# Address and scheme used by Caddy (development vs production)
-# In dev, use http://localhost to disable TLS and HSTS; in prod use your domain
-ADDR=http://localhost
-
-# Caddy toggle for automatic HTTPS (use 'auto_https off' in dev; blank in prod)
-AUTO_HTTPS=auto_https off
-
-# TLS directive (blank in dev; 'tls ${EMAIL}' in prod)
-TLS_DIRECTIVE=
-
-# HSTS line (set only in prod; blank in dev)
-HSTS_LINE=
-
 # Compose project name for docker-compose
 COMPOSE_PROJECT_NAME=loancalc
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ We follow Conventional Commits:
 
 ## Environment
 - Use .env.example for reference, never commit real secre- 
-- Dev mode: ADDR=http://localhost, auto_https off.
+- Dev mode: set DOMAIN=localhost and EMAIL=admin@example.com.
 - Prod mode: real domain with TLS.
 
 ## Testing

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,7 @@
-http://localhost {
+{$DOMAIN} {
   reverse_proxy /api/* api:8000
   root * /srv
   try_files {path} {path}/index.html
   file_server
+  tls {$EMAIL}
 }

--- a/README.md
+++ b/README.md
@@ -22,19 +22,15 @@ cd loan-calculator-trial
 
 # Set environment for local dev
 cp .env.example .env
-# Dev (no TLS):
-# ADDR=http://localhost
-# AUTO_HTTPS=auto_https off
-# TLS_DIRECTIVE=
-# HSTS_LINE=
+# Edit DOMAIN and EMAIL in .env
 
 # Run the stack
 ./deploy.sh --build
 
-# Open http://localhost
+# Open https://$DOMAIN
 ```
 
-For production, set `ADDR=${DOMAIN}`, `TLS_DIRECTIVE=tls ${EMAIL}`, and remove `AUTO_HTTPS` and `HSTS_LINE` from `.env`.
+Set `DOMAIN` to your hostname and `EMAIL` to the address used for Let's Encrypt certificates.
 
 ## API
 
@@ -71,14 +67,10 @@ Base URL in dev: `http://localhost`
 
 All settings live in `.env`:
 
-| var             | dev                | prod                                                                       | note                       |
-| --------------- | ------------------ | -------------------------------------------------------------------------- | -------------------------- |
-| `ADDR`          | `http://localhost` | `${DOMAIN}`                                                                | Caddy site address         |
-| `AUTO_HTTPS`    | `auto_https off`   | *(unset)*                                                                  | disable TLS in dev         |
-| `TLS_DIRECTIVE` | *(unset)*          | `tls ${EMAIL}`                                                             | prod TLS via Let’s Encrypt |
-| `HSTS_LINE`     | *(unset)*          | `Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"` | HSTS only in prod          |
-| `DOMAIN`        | *(optional)*       | your domain                                                                | used by Caddy TLS          |
-| `EMAIL`         | *(optional)*       | admin@yourdomain                                                           | used by Caddy TLS          |
+| var | dev | prod | note |
+| --- | --- | ---- | ---- |
+| `DOMAIN` | `localhost` | your domain | Caddy site address |
+| `EMAIL` | `admin@example.com` | admin@yourdomain | Let's Encrypt contact |
 
 ## CORS configuration
 
@@ -93,12 +85,7 @@ If `ALLOWED_ORIGINS` is not provided, cross‑origin requests will be blocked by
 Any Docker‑friendly host (Render, Railway, Fly.io, ECS, etc.) will work.
 
 1. Point DNS to your server.
-1. In `.env`, set:
-   ```
-   ADDR=${DOMAIN}
-   TLS_DIRECTIVE=tls ${EMAIL}
-   ```
-   and remove `AUTO_HTTPS` and `HSTS_LINE`.
+1. Set `DOMAIN` and `EMAIL` in `.env`.
 1. Run `./deploy.sh --build`.
 
 ## Linting & Formatting

--- a/deploy.sh
+++ b/deploy.sh
@@ -34,11 +34,6 @@ fi
 
 echo "Deployed. Checking health..."
 sleep 2
-# Use curl to check domain; fallback to localhost if .env set to http
-proto="https://"
-if echo "$(grep ^ADDR .env | cut -d= -f2)" | grep -q "http://"; then
-  proto="http://"
-fi
 domain=$(grep ^DOMAIN .env | cut -d= -f2)
-status=$(curl -Is $proto$domain | head -n 1 | sed 's/\r$//')
+status=$(curl -Is https://$domain | head -n 1 | sed 's/\r$//')
 echo "$status"

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -49,8 +49,8 @@ Provide a **fast, responsive, and extensible vehicle loan calculator** that can 
 1. **Deployment**
 
    - Docker Compose stack: `caddy` (reverse proxy), `web` (static), `api` (FastAPI).
-   - Caddy handles TLS in prod, auto-HTTPS disabled in dev.
-   - Configurable via `.env` (`ADDR`, `TLS_DIRECTIVE`, etc.).
+   - Caddy handles TLS via domain and email variables.
+   - Configurable via `.env` (`DOMAIN`, `EMAIL`).
 
 ## Non-Functional Requirements
 


### PR DESCRIPTION
## Summary
- use DOMAIN and EMAIL env vars in Caddyfile
- document domain/email config and add sample `.env`
- remove committed `.env` file to keep env vars out of version control

## Testing
- `make format` *(mdformat: command not found)*
- `pip install mdformat mdformat-gfm` *(proxy error: 403 Forbidden)*
- `make lint` *(yamllint: command not found)*
- `pip install yamllint` *(proxy error: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4749a1cc8332ad1a2a2d6e9734eb