### PR TITLE
chore: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set environment variables
+        run: |
+          echo "DOMAIN=${{ secrets.DOMAIN }}" >> $GITHUB_ENV
+          echo "EMAIL=${{ secrets.EMAIL }}" >> $GITHUB_ENV
+      - name: Run deploy script
+        run: ./deploy.sh --build --pull

--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ If `ALLOWED_ORIGINS` is not provided, cross‑origin requests will be blocked by
 
 Any Docker‑friendly host (Render, Railway, Fly.io, ECS, etc.) will work.
 
+Merges to `main` trigger a GitHub Actions workflow that runs `./deploy.sh --build --pull`. Set repository secrets `DOMAIN` and `EMAIL` beforehand.
+
 1. Point DNS to your server.
+1. Ensure repository secrets `DOMAIN` and `EMAIL` are configured in GitHub.
 1. In `.env`, set:
    ```
    ADDR=${DOMAIN}


### PR DESCRIPTION
## Summary
- add deploy workflow triggered on merges to `main`
- document GitHub Actions deployment and required secrets

## Testing
- `make lint` *(fails: `yamllint` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae474bf1c483328a6ff4847ab195ca