### PR TITLE
test: add loan quote calculation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ Merges to `main` trigger a GitHub Actions workflow that runs `./deploy.sh --buil
    and remove `AUTO_HTTPS` and `HSTS_LINE`.
 1. Run `./deploy.sh --build`.
 
+## Testing
+
+Run the test suite to verify loan calculations and API endpoints.
+
+```bash
+pip install -r requirements-dev.txt
+pytest
+```
+
 ## Linting & Formatting
 
 - Tools: `ruff` (Python), `black` (Python), `yamllint` (YAML), `mdformat` (Markdown).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,19 @@
+# Test Plan
+
+This plan outlines unit and integration tests for the loan quote service.
+
+## Unit Tests
+- **Standard calculation** – verifies amount financed, payment, interest, and total cost for typical values.
+- **Zero APR** – ensures no interest is charged when the APR is zero.
+- **Zero term** – validates handling when the term is zero, returning the principal with no payments.
+- **Trade-in exceeds price** – checks principal cannot go negative when trade-in value is higher than price.
+- **Negative APR validation** – confirms invalid APR values raise validation errors.
+
+## Integration Tests
+- **GET `/api/health`** – returns `{ "ok": true }`.
+- **POST `/api/quote`** – returns calculated values for a standard request.
+- **POST `/api/quote` with invalid APR** – responds with HTTP `422` for out-of-bound values.
+
+## Future Coverage
+- Endpoints for leads and affiliate tracking.
+- Front-end interactions and end-to-end scenarios.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ ruff==0.6.4
 yamllint==1.35.1
 mdformat==0.7.17
 mdformat-gfm==0.3.6
+pytest==8.2.0
+requests==2.31.0

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,128 @@
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from api.app import QuoteReq, app, quote
+
+client = TestClient(app)
+
+
+def test_quote_basic():
+    req = QuoteReq(
+        vehicle_price=20000,
+        down_payment=2000,
+        apr=3.0,
+        term_months=60,
+        tax_rate=0.07,
+        fees=500,
+        trade_in_value=0,
+    )
+    resp = quote(req)
+    assert resp.amount_financed == 19900.0
+    assert resp.monthly_payment == 357.58
+    assert resp.total_interest == 1554.62
+    assert resp.total_cost == 21454.62
+
+
+def test_quote_zero_apr():
+    req = QuoteReq(
+        vehicle_price=10000,
+        down_payment=0,
+        apr=0.0,
+        term_months=10,
+        tax_rate=0.0,
+        fees=0.0,
+        trade_in_value=0.0,
+    )
+    resp = quote(req)
+    assert resp.amount_financed == 10000.0
+    assert resp.monthly_payment == 1000.0
+    assert resp.total_interest == 0.0
+    assert resp.total_cost == 10000.0
+
+
+def test_quote_zero_term():
+    req = QuoteReq(
+        vehicle_price=10000,
+        down_payment=1000,
+        apr=5.0,
+        term_months=0,
+        tax_rate=0.0,
+        fees=0.0,
+        trade_in_value=0.0,
+    )
+    resp = quote(req)
+    assert resp.amount_financed == 9000.0
+    assert resp.monthly_payment == 0
+    assert resp.total_interest == 0
+    assert resp.total_cost == 9000.0
+
+
+def test_quote_trade_in_exceeds_price():
+    req = QuoteReq(
+        vehicle_price=10000,
+        down_payment=0,
+        apr=5.0,
+        term_months=60,
+        tax_rate=0.0,
+        fees=0.0,
+        trade_in_value=15000,
+    )
+    resp = quote(req)
+    assert resp.amount_financed == 0
+    assert resp.monthly_payment == 0
+    assert resp.total_interest == 0
+    assert resp.total_cost == 0
+
+
+def test_quote_negative_apr_validation():
+    with pytest.raises(ValidationError):
+        QuoteReq(
+            vehicle_price=10000,
+            down_payment=0,
+            apr=-1.0,
+            term_months=60,
+            tax_rate=0.0,
+            fees=0.0,
+            trade_in_value=0.0,
+        )
+
+
+def test_health_endpoint():
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_quote_endpoint_basic():
+    payload = {
+        "vehicle_price": 20000,
+        "down_payment": 2000,
+        "apr": 3.0,
+        "term_months": 60,
+        "tax_rate": 0.07,
+        "fees": 500,
+        "trade_in_value": 0,
+    }
+    resp = client.post("/api/quote", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "amount_financed": 19900.0,
+        "monthly_payment": 357.58,
+        "total_interest": 1554.62,
+        "total_cost": 21454.62,
+    }
+
+
+def test_quote_endpoint_validation_error():
+    payload = {
+        "vehicle_price": 10000,
+        "down_payment": 0,
+        "apr": -1.0,
+        "term_months": 60,
+        "tax_rate": 0.0,
+        "fees": 0.0,
+        "trade_in_value": 0.0,
+    }
+    resp = client.post("/api/quote", json=payload)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add unit and integration tests for loan quote API
- document test plan
- document how to run tests and include dev test dependencies

## Testing
- `ruff check api tests`
- `black --check api tests`
- `yamllint -s .` *(fails: command not found)*
- `mdformat --version` *(fails: command not found)*
- `pip install -r requirements-dev.txt` *(fails: Could not find a version)*
- `pip install fastapi` *(fails: Could not find a version)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ae7e7c894083329d5a8ff3f8517029