### PR TITLE
feat: persist leads with contact validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ EMAIL=admin@example.com
 # Compose project name for docker-compose
 COMPOSE_PROJECT_NAME=loancalc
 
+# Directory for persisted lead and tracking data
+PERSIST_DIR=/data
+

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Base URL in dev: `http://localhost`
   ```bash
   curl -s http://localhost/api/leads -X POST -H 'content-type: application/json' \
     -d '{"name":"Jane Doe","email":"jane@example.com","phone":"+14155551212","vehicle_type":"rv","price":75000,"affiliate":"partnerX"}'
-```
+  ```
+
+````
 
 Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
 
@@ -66,7 +68,7 @@ Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
   ```bash
   curl -s http://localhost/api/track -X POST -H 'content-type: application/json' \
     -d '{"affiliate":"partnerX"}'
-  ```
+````
 
 ## Front‑end
 
@@ -79,11 +81,11 @@ Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
 
 All settings live in `.env`:
 
-| var          | dev                 | prod                  | note                          |
-| ------------ | ------------------- | --------------------- | ----------------------------- |
-| `DOMAIN`     | `localhost`         | your domain           | Caddy site address            |
-| `EMAIL`      | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact         |
-| `PERSIST_DIR` | `/data`             | `/data` or custom dir | Persisted lead/track storage  |
+| var           | dev                 | prod                  | note                         |
+| ------------- | ------------------- | --------------------- | ---------------------------- |
+| `DOMAIN`      | `localhost`         | your domain           | Caddy site address           |
+| `EMAIL`       | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact        |
+| `PERSIST_DIR` | `/data`             | `/data` or custom dir | Persisted lead/track storage |
 
 ## CORS configuration
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Jump‑start your next ride with a fast, responsive vehicle loan payment calcula
 - 📊 **Cost breakdown chart**: smooth 3D pie chart with a CSS bounce effect highlighting principal vs interest, with the legend displayed outside the chart.
 - 🎰 **Rolling digits**: payment amounts animate with fast, smooth scrolling numbers.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
-- 👨‍⚖️ **Lead capture**: name/email/phone (+ affiliate/UTM captured automatically).
+- 👨‍⚖️ **Lead capture**: name/email/phone validated and persisted (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.
 - 💐 **API for dealerships**: compute quotes, accept leads.
 - 👨‍⚖️ **Dockerized**: Caddy (TLS), FastAPI, static web.
@@ -56,8 +56,10 @@ Base URL in dev: `http://localhost`
 
   ```bash
   curl -s http://localhost/api/leads -X POST -H 'content-type: application/json' \
-    -d '{"name":"Jane Doe","email":"jane@example.com","phone":"415-555-1212","vehicle_type":"rv","price":75000,"affiliate":"partnerX"}'
-  ```
+    -d '{"name":"Jane Doe","email":"jane@example.com","phone":"+14155551212","vehicle_type":"rv","price":75000,"affiliate":"partnerX"}'
+```
+
+Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
 
 - Affiliate tracking (POST JSON):
 
@@ -77,10 +79,11 @@ Base URL in dev: `http://localhost`
 
 All settings live in `.env`:
 
-| var      | dev                 | prod             | note                  |
-| -------- | ------------------- | ---------------- | --------------------- |
-| `DOMAIN` | `localhost`         | your domain      | Caddy site address    |
-| `EMAIL`  | `admin@example.com` | admin@yourdomain | Let's Encrypt contact |
+| var          | dev                 | prod                  | note                          |
+| ------------ | ------------------- | --------------------- | ----------------------------- |
+| `DOMAIN`     | `localhost`         | your domain           | Caddy site address            |
+| `EMAIL`      | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact         |
+| `PERSIST_DIR` | `/data`             | `/data` or custom dir | Persisted lead/track storage  |
 
 ## CORS configuration
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 WORKDIR /app
-RUN pip install --no-cache-dir fastapi uvicorn[standard]
+RUN pip install --no-cache-dir fastapi email-validator uvicorn[standard]
 COPY app.py .
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,15 @@ services:
   api:
     build: ./api
     restart: unless-stopped
+    volumes:
+      - data:/data
     networks:
       - loancalc
 
 volumes:
   caddy_data:
   caddy_config:
+  data:
 
 networks:
   loancalc:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ mdformat==0.7.17
 mdformat-gfm==0.3.6
 pytest==8.2.0
 requests==2.31.0
+fastapi==0.110.1
+email-validator==2.1.1
+uvicorn==0.29.0

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -1,0 +1,37 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+client = TestClient(app)
+
+
+def test_lead_persistence(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "phone": "+12345678901",
+    }
+    resp = client.post("/api/leads", json=payload)
+    assert resp.status_code == 200
+    leads_file = tmp_path / "leads.json"
+    assert leads_file.exists()
+    data = json.loads(leads_file.read_text())
+    assert data[0]["email"] == "alice@example.com"
+    assert data[0]["phone"] == "+12345678901"
+
+
+def test_lead_invalid_email(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {"name": "Bob", "email": "invalid", "phone": "+12345678901"}
+    resp = client.post("/api/leads", json=payload)
+    assert resp.status_code == 422
+
+
+def test_lead_invalid_phone(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {"name": "Bob", "email": "bob@example.com", "phone": "bad"}
+    resp = client.post("/api/leads", json=payload)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- validate lead emails and phone numbers and persist data to a configurable directory
- mount a volume for lead storage and document `PERSIST_DIR`
- cover new persistence and validation logic with tests

## Testing
- `ruff check api tests`
- `black --check api tests`
- `yamllint -s .` *(fails: command not found)*
- `mdformat --check README.md docs` *(fails: command not found)*
- `pytest` *(fails: No module named 'fastapi')*
- `PERSIST_DIR=/tmp uvicorn api.app:app --port 8001` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8d900cdc83329f73a24f925d2de1