### PR TITLE
fix: make caddy config adjustable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # Domain and email used by Caddy for Let's Encrypt
 DOMAIN=example.com
 EMAIL=admin@example.com
+# Address Caddy should bind to (use ":80" for local HTTP)
+ADDR=:80
+# TLS directive: leave empty for local, set to "tls ${EMAIL}" in production
+TLS_DIRECTIVE=
 
 # Compose project name for docker-compose
 COMPOSE_PROJECT_NAME=loancalc

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
-{$DOMAIN} {
+{$ADDR} {
   reverse_proxy /api/* api:8000
   root * /srv
   try_files {path} {path}/index.html
   file_server
-  tls {$EMAIL}
+  {$TLS_DIRECTIVE}
 }

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 VENV_PREFIX = .venv/bin/
 
-.PHONY: lint format lint-python lint-yaml lint-md lint-docker
+.PHONY: lint format lint-python lint-yaml lint-md lint-docker lint-caddy
 
-lint: lint-python lint-yaml lint-md ## Run all linters
+lint: lint-python lint-yaml lint-md lint-caddy ## Run all linters
 
 format: ## Auto-format Python and Markdown
 	$(VENV_PREFIX)black api
@@ -21,6 +21,9 @@ lint-md: ## mdformat --check
 
 lint-docker: ## Build lint image which runs checks at build-time
 	docker build -f Dockerfile.lint .
+
+lint-caddy: ## Validate Caddyfile syntax
+	docker run --rm -v $(PWD)/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2.8 caddy validate --config /etc/caddy/Caddyfile
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
 
 All settings live in `.env`:
 
-| var           | dev                 | prod                  | note                         |
-| ------------- | ------------------- | --------------------- | ---------------------------- |
-| `DOMAIN`      | `example.com`       | your domain           | Used by deploy script        |
-| `EMAIL`       | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact        |
-| `ADDR`        | `:80`               | `${DOMAIN}`           | Caddy site address           |
-| `TLS_DIRECTIVE` | _(empty)_        | `tls ${EMAIL}`        | Enables HTTPS in prod        |
-| `PERSIST_DIR` | `/data`             | `/data` or custom dir | Persisted lead/track storage |
+| var             | dev                 | prod                  | note                         |
+| --------------- | ------------------- | --------------------- | ---------------------------- |
+| `DOMAIN`        | `example.com`       | your domain           | Used by deploy script        |
+| `EMAIL`         | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact        |
+| `ADDR`          | `:80`               | `${DOMAIN}`           | Caddy site address           |
+| `TLS_DIRECTIVE` | _(empty)_           | `tls ${EMAIL}`        | Enables HTTPS in prod        |
+| `PERSIST_DIR`   | `/data`             | `/data` or custom dir | Persisted lead/track storage |
 
 ## CORS configuration
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ All settings live in `.env`:
 
 | var           | dev                 | prod                  | note                         |
 | ------------- | ------------------- | --------------------- | ---------------------------- |
-| `DOMAIN`      | `localhost`         | your domain           | Caddy site address           |
+| `DOMAIN`      | `example.com`       | your domain           | Used by deploy script        |
 | `EMAIL`       | `admin@example.com` | admin@yourdomain      | Let's Encrypt contact        |
+| `ADDR`        | `:80`               | `${DOMAIN}`           | Caddy site address           |
+| `TLS_DIRECTIVE` | _(empty)_        | `tls ${EMAIL}`        | Enables HTTPS in prod        |
 | `PERSIST_DIR` | `/data`             | `/data` or custom dir | Persisted lead/track storage |
 
 ## CORS configuration
@@ -111,8 +113,6 @@ Merges to `main` trigger a GitHub Actions workflow that runs `./deploy.sh --buil
    ADDR=${DOMAIN}
    TLS_DIRECTIVE=tls ${EMAIL}
    ```
-
-   and remove `AUTO_HTTPS` and `HSTS_LINE`.
 
 1. Run `./deploy.sh --build`.
 


### PR DESCRIPTION
## Summary
- allow Caddyfile to be driven by ADDR and TLS_DIRECTIVE env vars
- document ADDR and TLS_DIRECTIVE usage for local HTTP vs prod HTTPS
- add Makefile lint target to validate Caddyfile syntax

## Testing
- `python -m venv .venv`
- `.venv/bin/pip install -r requirements-dev.txt` *(fails: Could not connect to proxy)*
- `make lint` *(fails: .venv/bin/ruff: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae964f3a60833291f41ebce17b62e9