### PR TITLE
docs(agents): add explicit lint and formatting guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,42 @@ This project can be extended or maintained not only by humans but also by AI/aut
 6. **Testing**:
    - Manual curl commands for APIs.
    - Browser test for UI.
-   - Linting (Python + YAML + Markdown).
+   - Linting (Python + YAML + Markdown) — see Lint & Formatting.
+
+## Lint & Formatting
+Agents must follow the repository's configured linters/formatters and keep formatting changes scoped.
+
+- Python:
+  - Formatter: Black (line-length 88, Python 3.12). Config: `pyproject.toml`.
+  - Lint: Ruff (rules: E,F,W,I,UP,B; `E203`/`E501` ignored for Black). Config: `pyproject.toml`.
+  - Commands:
+    - Format: `make format` (formats Python under `api/`).
+    - Lint: `make lint-python` or all linters via `make lint`.
+
+- YAML:
+  - Lint: `yamllint` with repo rules. Config: `.yamllint.yaml`.
+  - Command: `make lint-yaml`.
+
+- Markdown:
+  - Formatter: `mdformat` with GitHub Flavored Markdown and wrap 88. Config: `pyproject.toml`.
+  - Commands:
+    - Format: `make format` (formats `README.md` and `docs/`).
+    - Lint/check: `make lint-md`.
+
+- Caddyfile:
+  - Validate syntax using official image. Command: `make lint-caddy`.
+
+- Docker build-time lint (optional local gate):
+  - Build `Dockerfile.lint` to run all checks in a clean environment: `make lint-docker`.
+
+- EditorConfig:
+  - Respect `.editorconfig` (LF endings, UTF-8, trim trailing whitespace; 2-space indent by default, 4 for `.py`, tabs for `Makefile`). Ensure your editor applies it.
+
+- Scope & PR hygiene:
+  - Do not mix broad formatting rewrites with feature/fix changes. If a formatter touches unrelated files, either:
+    - Limit formatting to files you edited, or
+    - Open a separate `chore: format` PR containing only formatting changes.
+  - All PRs must pass `make lint` before review.
 
 ## Communication
 - Use Pull Requests for all changes.


### PR DESCRIPTION
Add a new 'Lint & Formatting' section to AGENTS.md.

- Document Python tools: Black (88 cols, py312) and Ruff (E,F,W,I,UP,B) with config in pyproject.toml.
- Document YAML linting via yamllint using .yamllint.yaml.
- Document Markdown formatting via mdformat (GFM, wrap 88) with config in pyproject.toml.
- Add Caddyfile validation via make lint-caddy using official container.
- Add optional Docker lint image (make lint-docker) for clean, reproducible checks.
- Note .editorconfig conventions for line endings and indentation.
- Clarify scope rules to avoid noisy diffs; suggest separate 'chore: format' PR when needed.
- Require PRs to pass make lint before review.\n\nNo functional changes; documentation only.