### PR TITLE
chore: add build step to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run linters
+        run: make lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker images
+        run: docker compose build

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ pytest
   make lint-docker
   ```
 
+## Continuous Integration
+
+Pull requests trigger GitHub Actions to run linters and build all Docker images.
+
 ## Repository layout
 
 ```md


### PR DESCRIPTION
## Summary
- run linters and build Docker images for pull requests via CI
- document PR build checks in README

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement black==24.8.0)*
- `make lint` *(fails: .venv/bin/ruff: No such file or directory)*
- `docker compose build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a5a5aac8332839dd12de030073b