### PR TITLE
feat: add persistence validations and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 VENV_PREFIX = .venv/bin/
 
-.PHONY: lint format lint-python lint-yaml lint-md lint-docker
+.PHONY: lint format lint-python lint-yaml lint-md lint-docker test verify
 
 lint: lint-python lint-yaml lint-md ## Run all linters
 
@@ -21,6 +21,11 @@ lint-md: ## mdformat --check
 
 lint-docker: ## Build lint image which runs checks at build-time
 	docker build -f Dockerfile.lint .
+
+test: ## Run unit and integration tests
+	$(VENV_PREFIX)pytest
+
+verify: lint test ## Lint and run tests
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Base URL in dev: `http://localhost`
 
 ````
 
-Leads are stored in `leads.json` inside `PERSIST_DIR` (default `/data`).
+Leads are stored in `leads.json` and tracking events in `tracks.json`, both inside `PERSIST_DIR` (default `/data`). Lead names must be non-empty and phone numbers (if provided) must include 10–15 digits with an optional leading `+`. Affiliate identifiers must not be empty.
 
 - Affiliate tracking (POST JSON):
 
@@ -118,12 +118,14 @@ Merges to `main` trigger a GitHub Actions workflow that runs `./deploy.sh --buil
 
 ## Testing
 
-Run the test suite to verify loan calculations and API endpoints.
+Run linting and the test suite locally before building.
 
 ```bash
 pip install -r requirements-dev.txt
-pytest
+make verify  # or `make test` to run tests only
 ```
+
+`deploy.sh --build` automatically runs `make verify`.
 
 ## Linting & Formatting
 

--- a/api/app.py
+++ b/api/app.py
@@ -86,9 +86,9 @@ def _data_file(filename: str) -> str:
 
 
 class LeadReq(BaseModel):
-    name: str
+    name: constr(strip_whitespace=True, min_length=1)
     email: EmailStr
-    phone: constr(regex=r"^\+?[0-9]{10,15}$") | None = None
+    phone: constr(pattern=r"^\+?[0-9]{10,15}$") | None = None
     vehicle_type: str | None = None
     price: float | None = None
     affiliate: str | None = None
@@ -115,7 +115,7 @@ def create_lead(lead: LeadReq):
 
 
 class TrackReq(BaseModel):
-    affiliate: str
+    affiliate: constr(strip_whitespace=True, min_length=1)
 
 
 class TrackResp(BaseModel):

--- a/deploy.sh
+++ b/deploy.sh
@@ -19,6 +19,7 @@ if [ $PULL -eq 1 ]; then
 fi
 
 if [ $BUILD -eq 1 ]; then
+  make verify
   docker compose build --pull
 fi
 

--- a/tests/test_caddy.py
+++ b/tests/test_caddy.py
@@ -1,0 +1,9 @@
+import subprocess
+
+
+def test_caddy_health():
+    result = subprocess.run(
+        ["curl", "-I", "http://localhost"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "HTTP/" in result.stdout and (" 200" in result.stdout or " 301" in result.stdout)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,52 @@
+import json
+import os
+import subprocess
+import time
+
+import pytest
+import requests
+
+
+@pytest.fixture(scope="module")
+def live_server(tmp_path_factory):
+    data_dir = tmp_path_factory.mktemp("data")
+    env = os.environ.copy()
+    env["PERSIST_DIR"] = str(data_dir)
+    proc = subprocess.Popen(
+        ["uvicorn", "api.app:app", "--port", "8001"], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    time.sleep(1)
+    yield "http://127.0.0.1:8001", data_dir
+    proc.terminate()
+    proc.wait()
+
+
+def test_integration_quote(live_server):
+    base_url, _ = live_server
+    payload = {
+        "vehicle_price": 20000,
+        "down_payment": 2000,
+        "apr": 3.0,
+        "term_months": 60,
+        "tax_rate": 0.07,
+        "fees": 500,
+        "trade_in_value": 0,
+    }
+    resp = requests.post(f"{base_url}/api/quote", json=payload)
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "amount_financed": 19900.0,
+        "monthly_payment": 357.58,
+        "total_interest": 1554.62,
+        "total_cost": 21454.62,
+    }
+
+
+def test_integration_lead_persistence(live_server):
+    base_url, data_dir = live_server
+    payload = {"name": "Alice", "email": "alice@example.com", "phone": "+12345678901"}
+    resp = requests.post(f"{base_url}/api/leads", json=payload)
+    assert resp.status_code == 200
+    with open(data_dir / "leads.json") as f:
+        data = json.load(f)
+    assert data[0]["email"] == "alice@example.com"

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -1,8 +1,9 @@
 import json
-
+import pytest
+from pydantic import ValidationError
 from fastapi.testclient import TestClient
 
-from api.app import app
+from api.app import LeadReq, app
 
 client = TestClient(app)
 
@@ -35,3 +36,16 @@ def test_lead_invalid_phone(tmp_path, monkeypatch):
     payload = {"name": "Bob", "email": "bob@example.com", "phone": "bad"}
     resp = client.post("/api/leads", json=payload)
     assert resp.status_code == 422
+
+
+def test_lead_invalid_name(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {"name": "", "email": "bob@example.com", "phone": "+12345678901"}
+    resp = client.post("/api/leads", json=payload)
+    assert resp.status_code == 422
+
+
+def test_lead_model_phone_validation():
+    LeadReq(name="Carl", email="carl@example.com", phone="+12345678901")
+    with pytest.raises(ValidationError):
+        LeadReq(name="Carl", email="carl@example.com", phone="123")

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,0 +1,25 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+client = TestClient(app)
+
+
+def test_track_persistence(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {"affiliate": "partner1"}
+    resp = client.post("/api/track", json=payload)
+    assert resp.status_code == 200
+    track_file = tmp_path / "tracks.json"
+    assert track_file.exists()
+    data = json.loads(track_file.read_text())
+    assert data[0]["affiliate"] == "partner1"
+
+
+def test_track_invalid_affiliate(tmp_path, monkeypatch):
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    payload = {"affiliate": ""}
+    resp = client.post("/api/track", json=payload)
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- replace deprecated phone regex with pattern and document phone format
- add unit tests for lead validation and integration tests for quote and lead endpoints
- include Caddy smoke test to verify reverse proxy health
- run lint and tests during local build via new Makefile targets and deploy script hook

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement black==24.8.0)*
- `make verify` *(fails: .venv/bin/ruff: No such file or directory)*
- `make test` *(fails: .venv/bin/pytest: No such file or directory)*
- `curl -I http://localhost` *(fails: Failed to connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68ae915b8e808332b54a2fee1ffe53dd