### PR TITLE
feat: Pass Caddy env vars explicitly in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     environment:
       - DOMAIN=${DOMAIN}
       - EMAIL=${EMAIL}
+      - ADDR=${ADDR}
+      - TLS_DIRECTIVE=${TLS_DIRECTIVE}
     volumes:
       - caddy_data:/data
       - caddy_config:/config


### PR DESCRIPTION
This change explicitly passes the ADDR and TLS_DIRECTIVE environment variables to the Caddy service in docker-compose.yml.

This ensures that Caddy can correctly expand these variables in the Caddyfile, both for local development and in production environments.