### PR TITLE
fix: configure Caddy for apex and www hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,14 @@
 # Example environment file for vehicle loan calculator
 
-# Domain and email used by Caddy for Let's Encrypt
-DOMAIN=example.com
+# Hosts and email used by Caddy for Let's Encrypt
 APEX_HOST=example.com
 WWW_HOST=www.example.com
 EMAIL=admin@example.com
-# Address Caddy should bind to (use ":80" for local HTTP)
-ADDR=:80
-# TLS directive: leave empty for local, set to "tls ${EMAIL}" in production
-TLS_DIRECTIVE=
+# Optional HSTS header (uncomment in production)
+HSTS_LINE=
+
+# Allowed CORS origins (comma-separated, include apex and www hosts)
+ALLOWED_ORIGINS=https://example.com,https://www.example.com
 
 # Compose project name for docker-compose
 COMPOSE_PROJECT_NAME=loancalc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,31 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build Docker images
         run: docker compose build
+
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create .env
+        run: |
+          cat <<'EOT' > .env
+          APEX_HOST=example.com
+          WWW_HOST=www.example.com
+          EMAIL=admin@example.com
+          ALLOWED_ORIGINS=http://example.com
+          EOT
+      - name: Start services
+        run: docker compose up -d
+      - name: Curl Caddy
+        env:
+          APEX_HOST: example.com
+        run: curl -I -H "Host:${APEX_HOST}" http://localhost
+      - name: Run smoke tests
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          pip install -r requirements-dev.txt
+          pytest tests/test_smoke.py
+      - name: Tear down
+        if: always()
+        run: docker compose down

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,12 @@ jobs:
       - name: Write .env from secrets
         run: |
           cat <<'EOT' > .env
-          DOMAIN=${{ secrets.DOMAIN }}
-          EMAIL=${{ secrets.EMAIL }}
           APEX_HOST=${{ secrets.APEX_HOST }}
           WWW_HOST=${{ secrets.WWW_HOST }}
+          EMAIL=${{ secrets.EMAIL }}
+          HSTS_LINE=${{ secrets.HSTS_LINE }}
+          ALLOWED_ORIGINS=${{ secrets.ALLOWED_ORIGINS }}
+          PERSIST_DIR=/data
           EOT
       - name: Verify environment
         run: ./scripts/check-env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Environment variables
+# Environment variables (keep local secrets out of version control)
 .env
 *.env.*
 !*.env.example

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ We follow Conventional Commits:
 ## Environment
 
 - Use `.env.example` for reference, never commit real secrets.
-- Dev mode: set `DOMAIN=localhost` and `EMAIL=admin@example.com`.
+- Dev mode: set `APEX_HOST=localhost`, `WWW_HOST=localhost`, and `EMAIL=admin@example.com`.
 - Prod mode: real domain with TLS.
 
 ## Testing

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,20 @@
-{$ADDR} {
-	reverse_proxy /api/* api:8000
-	root * /srv
-	try_files {path} {path}/index.html
-	file_server 
-	{$TLS_DIRECTIVE}
+{$APEX_HOST}, {$WWW_HOST} {
+  @apex host {$APEX_HOST}
+  handle @apex {
+    redir https://{$WWW_HOST}{uri} permanent
+  }
+
+  @api path /api/*
+  handle @api {
+    reverse_proxy api:8000
+  }
+
+  handle {
+    root * /srv
+    try_files {path} {path}/index.html
+    file_server
+  }
+
+  tls {$EMAIL}
+  {$HSTS_LINE}
 }

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.12-slim
 WORKDIR /app
-RUN pip install --no-cache-dir fastapi email-validator uvicorn[standard]
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
 EXPOSE 8000
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/app.py
+++ b/api/app.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, constr
 
 app = FastAPI(title="Dealer Quote API", version="0.1.0")
 
@@ -89,7 +89,7 @@ def _data_file(filename: str) -> str:
 class LeadReq(BaseModel):
     name: str = Field(min_length=1)
     email: EmailStr
-    phone: Optional[str] = Field(default=None, pattern=r"^\+?[0-9]{10,15}$")
+    phone: Optional[constr(pattern=r"^\+?[0-9]{10,15}$")] = None
     vehicle_type: Optional[str] = None
     price: Optional[float] = None
     affiliate: Optional[str] = None

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.1
+pydantic==2.7.4
+email-validator==2.1.1
+uvicorn[standard]==0.29.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,10 @@ services:
       - "443:443"
     env_file: .env
     environment:
-      - DOMAIN=${DOMAIN}
+      - APEX_HOST=${APEX_HOST}
+      - WWW_HOST=${WWW_HOST}
       - EMAIL=${EMAIL}
-      - ADDR=${ADDR}
-      - TLS_DIRECTIVE=${TLS_DIRECTIVE}
+      - HSTS_LINE=${HSTS_LINE}
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -30,8 +30,11 @@ services:
   api:
     build: ./api
     restart: unless-stopped
+    environment:
+      - PERSIST_DIR=/data
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS}
     volumes:
-      - data:/data
+      - leads_data:/data
     networks:
       - loancalc
 
@@ -45,7 +48,7 @@ services:
 volumes:
   caddy_data:
   caddy_config:
-  data:
+  leads_data:
 
 networks:
   loancalc:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -49,8 +49,8 @@ Provide a **fast, responsive, and extensible vehicle loan calculator** that can 
 1. **Deployment**
 
    - Docker Compose stack: `caddy` (reverse proxy), `web` (static), `api` (FastAPI).
-   - Caddy handles TLS via domain and email variables.
-   - Configurable via `.env` (`DOMAIN`, `EMAIL`).
+   - Caddy handles TLS via host and email variables.
+   - Configurable via `.env` (`APEX_HOST`, `WWW_HOST`, `EMAIL`).
 
 ## Non-Functional Requirements
 

--- a/docs/SERVER_SETUP.md
+++ b/docs/SERVER_SETUP.md
@@ -18,7 +18,7 @@ keep verification in CI and local dev.
 
   ```bash
   cp .env.example .env
-  # Edit DOMAIN and EMAIL to match your setup
+  # Edit APEX_HOST, WWW_HOST, EMAIL, and ALLOWED_ORIGINS to match your setup
   ```
 
 ## Bootstrap the server (one time)
@@ -45,7 +45,7 @@ Steps:
 ./deploy.sh --build --pull
 
 # Check health
-curl -I http://$(grep ^DOMAIN .env | cut -d= -f2)
+curl -I -H "Host:$(grep ^APEX_HOST .env | cut -d= -f2)" http://localhost
 ```
 
 Why choose this option:
@@ -74,17 +74,10 @@ Notes:
 
 Key variables in `.env`:
 
-- `DOMAIN`: your domain (used by Caddy and health checks)
+- `APEX_HOST`: root domain
+- `WWW_HOST`: main site domain
 - `EMAIL`: Let’s Encrypt contact (for TLS in production)
-- `ADDR`: `:80` for local HTTP, `${DOMAIN}` for production
-- `TLS_DIRECTIVE`: empty for local; `tls ${EMAIL}` in production
-
-Example production values:
-
-```env
-ADDR=${DOMAIN}
-TLS_DIRECTIVE=tls ${EMAIL}
-```
+- `ALLOWED_ORIGINS`: comma-separated CORS origins
 
 ## Troubleshooting
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r api/requirements.txt
 black==24.8.0
 pre-commit==3.7.1
 ruff==0.6.4
@@ -7,8 +8,4 @@ mdformat==0.7.17
 mdformat-gfm==0.3.6
 pytest==8.2.0
 requests==2.31.0
-fastapi==0.110.1
-pydantic==2.7.4
-email-validator==2.1.1
-uvicorn==0.29.0
 httpx==0.27.0

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -6,7 +6,7 @@ if [ ! -f .env ]; then
   exit 1
 fi
 
-required_vars=(APEX_HOST WWW_HOST EMAIL DOMAIN)
+required_vars=(APEX_HOST WWW_HOST EMAIL ALLOWED_ORIGINS)
 missing=0
 
 for var in "${required_vars[@]}"; do

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,52 @@
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.app import app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    """Create a TestClient that writes data under a temp directory."""
+    monkeypatch.setenv("PERSIST_DIR", str(tmp_path))
+    return TestClient(app)
+
+
+def test_health(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_quote(client):
+    payload = {
+        "vehicle_price": 20000,
+        "down_payment": 2000,
+        "apr": 3.0,
+        "term_months": 60,
+    }
+    resp = client.post("/api/quote", json=payload)
+    assert resp.status_code == 200
+    body = resp.json()
+    for key in {"amount_financed", "monthly_payment", "total_interest", "total_cost"}:
+        assert key in body
+
+
+def test_leads_persist(client, tmp_path):
+    payload = {"name": "Alice", "email": "alice@example.com"}
+    resp = client.post("/api/leads", json=payload)
+    assert resp.status_code == 200
+
+    leads_file = tmp_path / "leads.json"
+    assert leads_file.exists()
+    data = json.loads(leads_file.read_text())
+    assert data[0]["email"] == "alice@example.com"
+
+
+def test_track_persist(client, tmp_path):
+    resp = client.post("/api/track", json={"affiliate": "partner"})
+    assert resp.status_code == 200
+
+    track_file = tmp_path / "tracks.json"
+    assert track_file.exists()


### PR DESCRIPTION
## Summary
- redirect apex host to www and serve both from a single site block
- proxy /api requests without stripping the prefix
- use environment placeholders for hosts, TLS email, and HSTS header
- pass Caddy host settings via compose and persist API data in a named volume
- document env vars including ALLOWED_ORIGINS and keep real .env out of version control
- auto-generate .env when host vars are provided and pin API dependencies
- add smoke tests and CI curl check for Caddy
- run API smoke tests in-memory with TestClient and verify leads/track persistence

## Testing
- `python -m venv .venv`
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.1)*
- `make format` *(fails: docker: command not found)*
- `make lint` *(fails: .venv/bin/ruff: No such file or directory)*
- `make lint-caddy` *(fails: docker: command not found)*
- `pytest tests/test_smoke.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `curl -I -H "Host:example.com" http://localhost` *(fails: Failed to connect to localhost port 80)*

------
https://chatgpt.com/codex/tasks/task_e_68b131c122ec833299d8e086280d9651