### PR TITLE
chore(release): add release tagging, rollback scripts, and prod validation taget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,14 @@ verify: lint test ## Lint and run tests
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' Makefile | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $1, $2}' | sort
+
+.PHONY: prod-validate release-tag rollback
+
+prod-validate: ## Validate production hosts using curl (requires APEX_HOST, WWW_HOST)
+	@bash scripts/validate_caddy_prod.sh
+
+release-tag: ## Create an annotated release tag: make release-tag VERSION=vX.Y.Z [VERIFY=1] [PUSH=1]
+	@bash scripts/release_tag.sh $(VERSION) $(if $(VERIFY),--verify,) $(if $(PUSH),--push,)
+
+rollback: ## Roll back to a tag/commit: make rollback REF=<git-ref> [BUILD=1] [VERIFY=1] [YES=1]
+	@bash scripts/rollback_to.sh $(REF) $(if $(BUILD),--build,) $(if $(VERIFY),--verify,) $(if $(YES),--yes,)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,23 @@ CADDY_HEALTH_URL=http://localhost:8080 pytest --run-external
 
 # Run only fast, hermetic tests (default behavior)
 pytest -k 'not external'
+
+## Releases & Rollback
+
+- Tag a release:
+  - `make release-tag VERSION=v0.1.0 VERIFY=1 PUSH=1`
+    - Creates an annotated git tag (runs linters/tests if `VERIFY=1`) and pushes it if `PUSH=1`.
+
+- Deploy a specific version (on server):
+  - `git checkout v0.1.0 && ./deploy.sh -b --verify`
+
+- Roll back to a previous version (scripted):
+  - `make rollback REF=v0.1.0 BUILD=1 VERIFY=1 YES=1`
+    - Checks out the ref and redeploys via `deploy.sh`.
+
+Notes:
+- Ensure `.env` is present on the server with your production values before deploying.
+- If you prefer image-based releases, configure your container registry and extend the scripts to build/push images per tag.
 ```
 
 ## Linting & Formatting

--- a/scripts/release_tag.sh
+++ b/scripts/release_tag.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 <version> [--push] [--verify]
+
+Creates an annotated git tag for a release and (optionally) pushes it.
+
+Arguments:
+  <version>   Version string, e.g. v0.1.0 (must start with 'v')
+
+Options:
+  --push      Push the tag to origin
+  --verify    Run 'make verify' before tagging (requires dev deps)
+
+Examples:
+  $0 v0.1.0 --verify --push
+EOF
+}
+
+if [[ $# -lt 1 ]]; then usage; exit 1; fi
+
+VERSION="$1"; shift || true
+PUSH=0; VERIFY=0
+for arg in "$@"; do
+  case "$arg" in
+    --push) PUSH=1 ;;
+    --verify) VERIFY=1 ;;
+    -h|--help) usage; exit 0 ;;
+  esac
+done
+
+[[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Version must look like vX.Y.Z"; exit 1; }
+
+# Ensure clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Working tree has changes. Commit or stash before tagging."; exit 1
+fi
+
+if [[ $VERIFY -eq 1 ]]; then
+  if command -v make >/dev/null 2>&1; then
+    make verify
+  else
+    echo "make not found; skipping verify. Re-run with make installed or omit --verify."; exit 1
+  fi
+fi
+
+# Create annotated tag
+if git rev-parse "$VERSION" >/dev/null 2>&1; then
+  echo "Tag $VERSION already exists."; exit 1
+fi
+
+git tag -a "$VERSION" -m "Release $VERSION"
+echo "Created tag $VERSION"
+
+if [[ $PUSH -eq 1 ]]; then
+  git push origin "$VERSION"
+  echo "Pushed tag $VERSION to origin"
+fi
+
+echo "Done. Deploy with: git checkout $VERSION && ./deploy.sh -b --verify"
+

--- a/scripts/rollback_to.sh
+++ b/scripts/rollback_to.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 <git-ref> [--build] [--verify] [--yes]
+
+Checks out a specific git ref (tag or commit) and redeploys.
+
+Arguments:
+  <git-ref>   Git tag (e.g., v0.1.0) or commit SHA
+
+Options:
+  --build     Rebuild images before starting (maps to deploy.sh -b)
+  --verify    Run linters/tests during build (maps to deploy.sh --verify)
+  --yes       Non-interactive mode (skip confirmation prompt)
+
+Examples:
+  $0 v0.1.0 --build --verify --yes
+EOF
+}
+
+if [[ $# -lt 1 ]]; then usage; exit 1; fi
+
+REF="$1"; shift || true
+BUILD=0; VERIFY=0; YES=0
+for arg in "$@"; do
+  case "$arg" in
+    --build)  BUILD=1 ;;
+    --verify) VERIFY=1 ;;
+    --yes)    YES=1 ;;
+    -h|--help) usage; exit 0 ;;
+  esac
+done
+
+# Ensure git ref exists locally or fetch tags
+if ! git rev-parse --verify --quiet "$REF" >/dev/null; then
+  echo "Ref '$REF' not found locally. Fetching tags..."
+  git fetch --tags --all --prune
+  git rev-parse --verify --quiet "$REF" >/dev/null || { echo "Ref '$REF' not found after fetch."; exit 1; }
+fi
+
+if [[ $YES -eq 0 ]]; then
+  read -r -p "Checkout '$REF' and redeploy? This will change the working tree. [y/N] " ans
+  [[ "$ans" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 1; }
+fi
+
+# Ensure no uncommitted changes to avoid accidental loss
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "Working tree has changes. Commit/stash before rollback."; exit 1
+fi
+
+git checkout "$REF"
+echo "Checked out $(git rev-parse --short HEAD) for ref $REF"
+
+ARGS=()
+[[ $BUILD -eq 1 ]] && ARGS+=("-b")
+[[ $VERIFY -eq 1 ]] && ARGS+=("--verify")
+
+./deploy.sh "${ARGS[@]}"
+
+echo "Rollback to $REF complete."
+

--- a/scripts/validate_caddy_prod.sh
+++ b/scripts/validate_caddy_prod.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate production Caddy deployment behavior using curl and openssl.
+# Requires env vars: APEX_HOST, WWW_HOST
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[OK] $*"; }
+
+APEX_HOST=${APEX_HOST:-}
+WWW_HOST=${WWW_HOST:-}
+HSTS_LINE=${HSTS_LINE:-}
+
+[[ -n "$APEX_HOST" ]] || fail "APEX_HOST is required"
+[[ -n "$WWW_HOST" ]] || fail "WWW_HOST is required"
+
+echo "Validating Caddy production at apex=$APEX_HOST, www=$WWW_HOST"
+
+# 1) Apex HTTP -> redirect to https://WWW_HOST
+code=$(curl -s -o /dev/null -w '%{http_code}' -I "http://$APEX_HOST/") || true
+[[ "$code" == "301" || "$code" == "308" ]] || fail "Apex HTTP expected 301/308, got $code"
+loc=$(curl -s -I "http://$APEX_HOST/" | awk -v IGNORECASE=1 '/^Location:/ {print $2}' | tr -d '\r')
+[[ "$loc" == https://$WWW_HOST/* || "$loc" == https://$WWW_HOST ]] || fail "Apex Location should point to https://$WWW_HOST, got '$loc'"
+pass "Apex HTTP redirects to $loc ($code)"
+
+# 2) WWW HTTP -> redirect to HTTPS
+code=$(curl -s -o /dev/null -w '%{http_code}' -I "http://$WWW_HOST/") || true
+[[ "$code" == "301" || "$code" == "308" ]] || fail "WWW HTTP expected 301/308, got $code"
+loc=$(curl -s -I "http://$WWW_HOST/" | awk -v IGNORECASE=1 '/^Location:/ {print $2}' | tr -d '\r')
+[[ "$loc" == https://$WWW_HOST/* || "$loc" == https://$WWW_HOST ]] || fail "WWW Location should point to https://$WWW_HOST, got '$loc'"
+pass "WWW HTTP redirects to $loc ($code)"
+
+# 3) WWW HTTPS serves HTML with 200
+code=$(curl -s -o /dev/null -w '%{http_code}' "https://$WWW_HOST/") || true
+[[ "$code" == "200" ]] || fail "HTTPS GET expected 200, got $code"
+ctype=$(curl -s -I "https://$WWW_HOST/" | awk -v IGNORECASE=1 '/^Content-Type:/ {print tolower($2)}' | tr -d '\r')
+echo "$ctype" | grep -qi 'text/html' || fail "Content-Type should include text/html, got '$ctype'"
+pass "WWW HTTPS returns 200 and HTML"
+
+# 4) Optional HSTS header when configured
+if [[ -n "${HSTS_LINE}" ]]; then
+  hsts=$(curl -s -I "https://$WWW_HOST/" | awk -v IGNORECASE=1 '/^Strict-Transport-Security:/ {print $0}')
+  [[ -n "$hsts" ]] || fail "HSTS expected, but not present"
+  pass "HSTS header present: $hsts"
+else
+  echo "HSTS not required (HSTS_LINE not set)"
+fi
+
+# 5) TLS is valid (curl will error on invalid cert). Show issuer/dates for visibility.
+curl -sSfI "https://$WWW_HOST/" >/dev/null || fail "TLS handshake or HTTP HEAD failed"
+if command -v openssl >/dev/null 2>&1; then
+  echo "Certificate info (issuer, dates):"
+  echo | openssl s_client -servername "$WWW_HOST" -connect "$WWW_HOST:443" 2>/dev/null | openssl x509 -noout -issuer -dates || true
+fi
+pass "TLS validated by curl"
+
+# 6) Redirect loop safety check (should be 0 after reaching HTTPS root)
+loops=$(curl -s -o /dev/null -w '%{num_redirects}' -L "https://$WWW_HOST/")
+[[ "$loops" == "0" ]] || fail "Unexpected redirects on HTTPS root (num_redirects=$loops)"
+pass "No redirects on HTTPS root"
+
+echo "All production checks passed."
+


### PR DESCRIPTION
## Summary

- Introduces lightweight release management and rollback tooling.
- Adds a production validation script for Caddy (redirects, TLS, HSTS, no loops).
- Exposes Makefile targets to operate these flows.
- Documents the workflow.

## Scope

- Atomic change focused on release + rollback + prod validation.
- No changes to app logic, API, Caddy routing, or Compose.
- No secrets added; .env untouched.

## Changes

- scripts/release_tag.sh: Create annotated tag vX.Y.Z (options: --verify, --push).
- scripts/rollback_to.sh: Checkout tag/commit and redeploy via deploy.sh (options: --build, --verify, --yes).
- scripts/validate_caddy_prod.sh: Curl/openssl checks for apex→www redirect, HTTP→HTTPS, HTTPS 200 HTML, optional HSTS, and
no redirect loops.
- Makefile:
    - prod-validate: runs the prod validation script.
    - release-tag: wraps release_tag.sh.
    - rollback: wraps rollback_to.sh.
- README: Adds “Releases & Rollback” usage.

## Usage

- Tag release: make release-tag VERSION=v0.1.0 VERIFY=1 PUSH=1
- Deploy tag on server: git checkout v0.1.0 && ./deploy.sh -b --verify
- Rollback: make rollback REF=v0.1.0 BUILD=1 VERIFY=1 YES=1
- Prod validate:
    - export APEX_HOST=example.com WWW_HOST=www.example.com
    - make prod-validate

## Validation

- Lint: make lint passes (Ruff, Black, YAML, Markdown, Caddy validate).
- Tests: make test → 23 passed, 1 skipped.
- External: pytest -q -m external --run-external passed; localhost responded.
- Caddy: make lint-caddy validates.

## Operational Notes

- Tools work with existing deploy.sh (no infra changes).
- Scripts guard against dirty working trees and missing refs.
- Safe default behavior; explicit flags to verify/push/build.

## Risks

- Low. Scripts and docs only; no behavioral changes to runtime services.

## Backout

- Revert this PR or simply avoid using the new targets/scripts.
- Existing deploy flow remains unchanged.

## Checklist

- Lint/format pass.
- Tests pass.
- Docs updated.
- Atomic change aligned with Agents guidelines (no mixed scope, no secrets).