### PR TITLE
chore(build): add separate dev/release build flows

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.lint
-    image: loancalc/lint:latest
+    profiles: ["dev"]
     # Building this service runs all linters at build-time
   caddy:
     image: caddy:2.8


### PR DESCRIPTION
- Description:
    - Add Make targets:
    - build-dev: runs verify, builds all services
    - build-release: builds only runtime images (api, web)
- Add scripts:
    - scripts/build-dev.sh
    - scripts/build-release.sh
- Update deploy.sh:
    - Build only api/web with --build
    - Optional --verify to run linters/tests
- Docs: Document build modes in README
- Testing:
    - Local: make build-dev (passes verify, builds all)
    - Release: make build-release (builds only api/web)
    - Deploy: ./deploy.sh --build (waits for Caddy; no dev tools needed)
- No env or secret changes.