### PR TITLE
docs: add v2 release planning documents

### DIFF
--- a/docs/v2-release/PRD.md
+++ b/docs/v2-release/PRD.md
@@ -1,0 +1,42 @@
+# Loan Calculator Platform v2 PRD
+
+## Overview
+
+The v2 release focuses on making the loan calculator platform modular and mobile-
+ready. Each calculator is hosted on its own path under `vibesforce.com` and
+exposes APIs that can be reused by web and mobile clients.
+
+## Goals
+
+- Provide vehicle, mortgage, HELOC, and personal loan calculators.
+- Generate monthly amortization schedules for all loan types.
+- Serve calculators as embeddable components and REST APIs.
+- Introduce a swipe-based Partners & Products page for affiliate offers.
+- Migrate data storage to Google Cloud SQL.
+- Gate amortization schedules and exports behind email capture for lead
+  generation and future verification.
+
+## User Stories
+
+- **Borrower** wants to compare loan options and view monthly payments.
+- **Affiliate marketer** wants to display partner offers to users.
+- **Mobile developer** wants to embed calculators inside native apps.
+
+## Functional Requirements
+
+1. Calculators accept loan amount, term, interest rate, and related inputs.
+1. API returns monthly amortization schedule with principal and interest break-
+   down.
+1. Partners page shows swipeable cards with key offer details.
+1. All calculators and partners API endpoints are versioned under `/api/v1/`.
+1. Data is stored in Cloud SQL with migration scripts.
+1. Viewing amortization schedules or exports requires users to submit an
+   email address.
+1. Captured emails are stored as leads and can be verified later to ensure
+   legitimate users.
+
+## Non-functional Requirements
+
+- Responsive UI for desktop and mobile web.
+- API latency under 300 ms for typical calculations.
+- Code and documentation linted and formatted per repo guidelines.

--- a/docs/v2-release/multi-sprint-plan.md
+++ b/docs/v2-release/multi-sprint-plan.md
@@ -1,0 +1,32 @@
+# Multi Sprint Plan with Daily Tasks
+
+## Sprint 1: Calculator Modularization (Week 1)
+
+- **Day 1-2**: Finalize API contracts and DB schema.
+- **Day 3**: Implement vehicle calculator module.
+- **Day 4**: Implement mortgage calculator module.
+- **Day 5**: Implement HELOC and personal loan modules.
+
+## Sprint 2: Amortization & Cloud SQL (Week 2)
+
+- **Day 1**: Add monthly amortization logic to all calculators.
+- **Day 2**: Implement email capture gating for amortization and export
+  requests.
+- **Day 3**: Generate CSV/PDF exports behind the email gate.
+- **Day 4**: Set up Cloud SQL instance and migrations.
+- **Day 5**: Integrate database layer with calculators and deploy to staging
+  for integration tests.
+
+## Sprint 3: Partners Swipe Page (Week 3)
+
+- **Day 1-2**: Design card model and swipe interactions.
+- **Day 3**: Implement backend endpoints for partners.
+- **Day 4**: Build swipe UI component.
+- **Day 5**: QA and finalize partners page.
+
+## Future Sprint: Email Verification
+
+- **Day 1-2**: Design verification workflow and token handling.
+- **Day 3**: Implement verification endpoint and update lead records.
+- **Day 4**: Hook verification into calculators.
+- **Day 5**: QA end-to-end lead verification.

--- a/docs/v2-release/release-plan.md
+++ b/docs/v2-release/release-plan.md
@@ -1,0 +1,30 @@
+# Release Plan for Loan Calculator Platform v2
+
+## Milestones
+
+1. **MVP Calculators**
+   - Target: End of Sprint 1
+   - Deliver vehicle, mortgage, HELOC, and personal calculators with basic UI.
+1. **Amortization & Cloud SQL**
+   - Target: End of Sprint 2
+   - Include monthly amortization, exports gated by email capture, and Cloud SQL
+     migration.
+1. **Partners & Products Page**
+   - Target: End of Sprint 3
+   - Swipe interface available with partner data.
+1. **Email Verification**
+   - Target: Post-Partners release
+   - Validate captured emails to confirm legitimate leads.
+
+## Deployment Steps
+
+1. Run database migrations on Cloud SQL.
+1. Build and push Docker images to registry.
+1. Deploy services to Cloud Run.
+1. Invalidate CDN cache for updated static assets.
+1. Smoke test calculators and partners page in production.
+
+## Rollback Strategy
+
+- Maintain previous container image tags.
+- Restore database from latest backup if migrations fail.

--- a/docs/v2-release/technical-design.md
+++ b/docs/v2-release/technical-design.md
@@ -1,0 +1,49 @@
+# Technical Design for Loan Calculator Platform v2
+
+## Architecture
+
+- **Frontend**: Modular web components for each calculator and the partners page.
+- **Backend**: REST API built with FastAPI under `/api/v1/` providing calculation
+  logic and partner offer management.
+- **Database**: PostgreSQL instance on Google Cloud SQL accessed via SQLAlchemy
+  with migration scripts in `scripts/migrations`.
+- **Hosting**: Containers deployed to Cloud Run; static assets served via Caddy.
+
+## Module Layout
+
+```
+docs/
+api/
+  calculators/
+    vehicle.py
+    mortgage.py
+    heloc.py
+    personal.py
+  partners/
+    endpoints.py
+web/
+  components/
+    calculator-widget.js
+    partner-cards.js
+```
+
+## APIs
+
+- `POST /api/v1/calculators/<type>`: returns monthly amortization schedule.
+- `GET /api/v1/partners`: returns swipe card data.
+- `POST /api/v1/leads`: captures user email and returns a token required for
+  amortization schedules or export downloads.
+
+## Lead Capture and Verification
+
+- Emails are stored in a `leads` table with fields for address, token, and
+  verification status.
+- Calculator endpoints verify a valid lead token before generating amortization
+  schedules or exports.
+- Future enhancement: send verification emails containing a signed link that
+  marks the lead as verified when clicked.
+
+## Cloud SQL Migration
+
+- Use `scripts/migrate.py` to apply Alembic migrations.
+- Environment variables stored in `.env` and `.env.example` documents.

--- a/docs/v2-release/test-plan.md
+++ b/docs/v2-release/test-plan.md
@@ -1,0 +1,32 @@
+# Test Plan for Loan Calculator Platform v2
+
+## Objectives
+
+Ensure calculators produce correct amortization schedules and partners page works
+across devices.
+
+## Test Areas
+
+1. **Unit Tests**
+   - Calculation functions for each loan type.
+   - Database access layers.
+1. **API Tests**
+   - `/api/v1/calculators/<type>` returns expected JSON.
+   - `/api/v1/partners` returns valid card data.
+   - `/api/v1/leads` stores email and issues access token.
+   - Calculators reject amortization or export requests without a valid token.
+1. **UI Tests**
+   - Responsive layout for calculators and swipe page.
+   - Swipe gestures perform accept/dismiss actions.
+   - Amortization and export features prompt for email and unlock after
+     submission.
+1. **Performance Tests**
+   - API responses within 300 ms under normal load.
+1. **Regression**
+   - Existing v1 features remain functional.
+
+## Tools
+
+- Pytest for unit and API tests.
+- Playwright for end-to-end browser tests.
+- Locust for performance testing.


### PR DESCRIPTION
## Summary
- add PRD outlining modular calculators, monthly amortization, partner swipe page, and Cloud SQL migration
- document technical architecture, multi-sprint schedule, test plan, and release process for v2
- gate amortization and exports behind email capture with future verification planning

## Testing
- `make format` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `make lint` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `make lint-md`


------
https://chatgpt.com/codex/tasks/task_e_68b27e9ebd8883329629edc1bb696d24