### PR TITLE
infra: shared app_data across blue/green + CI volume smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,42 @@ jobs:
         if: always()
         run: |
           kill $(cat uvicorn.pid) 2>/dev/null || true
+
+  volume-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare shared network and volumes
+        run: |
+          docker network create edge-net || true
+          docker volume create edge_caddy_data || true
+          docker volume create app_data || true
+      - name: Bring up blue stack with compose
+        env:
+          PROJECT_NAME: loancalc-blue
+        run: |
+          docker compose -p "$PROJECT_NAME" up -d --build caddy api web
+      - name: Wait for API health
+        env:
+          PROJECT_NAME: loancalc-blue
+        run: |
+          docker run --rm --network=${PROJECT_NAME}_default curlimages/curl:latest -sSf http://api:8000/api/health > /dev/null
+      - name: Assert app_data volume exists
+        run: |
+          docker volume inspect app_data >/dev/null
+      - name: Assert /data mount in API container uses app_data
+        env:
+          PROJECT_NAME: loancalc-blue
+        run: |
+          CID=$(docker ps -q --filter "label=com.docker.compose.service=api" --filter "label=com.docker.compose.project=${PROJECT_NAME}")
+          echo "API container: $CID"
+          test -n "$CID"
+          docker inspect "$CID" | tee /tmp/inspect.json >/dev/null
+          grep -q '"Destination": "/data"' /tmp/inspect.json
+          grep -q '"Name": "app_data"' /tmp/inspect.json
+      - name: Tear down blue stack
+        if: always()
+        env:
+          PROJECT_NAME: loancalc-blue
+        run: |
+          docker compose -p "$PROJECT_NAME" down --remove-orphans || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,10 @@ jobs:
         env:
           PROJECT_NAME: loancalc-blue
         run: |
-          docker run --rm --network=${PROJECT_NAME}_default curlimages/curl:latest -sSf http://api:8000/api/health > /dev/null
+          docker run --rm \
+            --network=${PROJECT_NAME}_default \
+            curlimages/curl:latest -sSf http://api:8000/api/health \
+            > /dev/null
       - name: Assert app_data volume exists
         run: |
           docker volume inspect app_data >/dev/null
@@ -131,7 +134,11 @@ jobs:
         env:
           PROJECT_NAME: loancalc-blue
         run: |
-          CID=$(docker ps -q --filter "label=com.docker.compose.service=api" --filter "label=com.docker.compose.project=${PROJECT_NAME}")
+          CID=$(
+            docker ps -q \
+              --filter "label=com.docker.compose.service=api" \
+              --filter "label=com.docker.compose.project=${PROJECT_NAME}"
+          )
           echo "API container: $CID"
           test -n "$CID"
           docker inspect "$CID" | tee /tmp/inspect.json >/dev/null

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Base URL in dev: `http://localhost`
     -d '{"name":"Jane Doe","email":"jane@example.com","phone":"+14155551212","vehicle_type":"rv","price":75000,"affiliate":"partnerX"}'
   ```
 
-Leads are stored in `leads.json` and tracking events in `tracks.json`, both inside `PERSIST_DIR` (default `/data`). Lead names must be non-empty and phone numbers (if provided) must include 10–15 digits with an optional leading `+`. Affiliate identifiers must not be empty. Invalid submissions are rejected and not written to disk.
+Leads are stored in `leads.json` and tracking events in `tracks.json`, both inside `PERSIST_DIR` (default `/data`). In Docker deployments, `/data` is backed by a named volume `app_data` shared across blue/green, so data persists through cutovers. Lead names must be non-empty and phone numbers (if provided) must include 10–15 digits with an optional leading `+`. Affiliate identifiers must not be empty. Invalid submissions are rejected and not written to disk.
 
 - Affiliate tracking (POST JSON):
 
@@ -87,7 +87,7 @@ This project supports blue‑green deployment to minimize downtime. See [Release
 - Production prerequisites:
 
   - `.env` has: `DOMAIN`, `APEX_HOST`, `WWW_HOST`, `EMAIL`, and `TLS_DIRECTIVE=tls ${EMAIL}`.
-  - One‑time infra: `docker network create edge-net` and `docker volume create edge_caddy_data`.
+  - One‑time infra: `docker network create edge-net && docker volume create edge_caddy_data && docker volume create app_data`.
   - Cloudflare (if used): SSL/TLS mode “Full” or “Full (strict)”, apex/www DNS → server IP.
   - Never commit a real `.env`. Keep only `.env.example` in git and generate `.env` in CI/CD or locally.
 
@@ -102,6 +102,15 @@ This project supports blue‑green deployment to minimize downtime. See [Release
   - `make validate-local` brings up a color stack, points edge to it, and verifies:
     - `http://localhost` returns HTML
     - `http://localhost/api/health` returns `{ "ok": true }`
+
+### Persistent data and inspection
+
+The API writes JSON to `PERSIST_DIR` (default `/data`). In Docker, this path is mounted from the shared named volume `app_data`, so both blue and green environments use the same data.
+
+- List files (blue): `docker compose -p loancalc-blue exec api sh -lc 'ls -lah ${PERSIST_DIR:-/data}'`
+- Show leads (blue): `docker compose -p loancalc-blue exec api sh -lc 'cat ${PERSIST_DIR:-/data}/leads.json || echo "no leads.json"'`
+- Show tracks (blue): `docker compose -p loancalc-blue exec api sh -lc 'cat ${PERSIST_DIR:-/data}/tracks.json || echo "no tracks.json"'`
+- Replace `loancalc-blue` with `loancalc-green` to inspect the other color.
 
 ## Testing
 
@@ -164,6 +173,8 @@ pytest -k 'not external'
 ## Continuous Integration
 
 Pull requests trigger GitHub Actions to run linters and build all Docker images.
+
+- Includes a compose smoke job that boots a blue stack, verifies `/api/health`, asserts the `app_data` Docker volume exists, and confirms it is mounted at `/data` in the API container.
 
 ## Repository layout
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -35,6 +35,16 @@ Before you can deploy, you need the following:
 1.  **Docker and Docker Compose:** These are required to build and run the application.
 2.  **A Main Caddy Instance:** You need a main Caddy instance running on the host that acts as the front-facing reverse proxy. This Caddy instance is responsible for routing traffic to the active environment (blue or green).
 
+### One-time network and volumes
+
+Create the shared Docker network and volumes used by edge Caddy and API data:
+
+```bash
+docker network create edge-net || true
+docker volume create edge_caddy_data || true
+docker volume create app_data || true
+```
+
 ### Running the Main Caddy Instance
 
 To run the main Caddy instance, you can use the following command:

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,9 +20,10 @@ if [ "$ENV" != "blue" ] && [ "$ENV" != "green" ]; then
   exit 1
 fi
 
-# Create external network and volume if they don't exist
+# Create external network and volumes if they don't exist
 docker network create edge-net || true
 docker volume create edge_caddy_data || true
+docker volume create app_data || true
 
 # Set environment variables based on the chosen environment
 if [ "$ENV" == "blue" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     restart: unless-stopped
     networks:
       - default
+    volumes:
+      - app_data:/data
 
   web:
     build: ./web
@@ -56,6 +58,8 @@ services:
 
 volumes:
   edge_caddy_data:
+    external: true
+  app_data:
     external: true
 
 networks:

--- a/scripts/validate_local.sh
+++ b/scripts/validate_local.sh
@@ -9,6 +9,7 @@ DOMAIN=${DOMAIN:-localhost}
 echo "[validate-local] Creating shared network/volume if missing..."
 docker network create edge-net >/dev/null 2>&1 || true
 docker volume create edge_caddy_data >/dev/null 2>&1 || true
+docker volume create app_data >/dev/null 2>&1 || true
 
 COLOR=${1:-blue}
 if [[ "$COLOR" != "blue" && "$COLOR" != "green" ]]; then


### PR DESCRIPTION
1) Summary
- Adds shared Docker volume `app_data` mounted at `/data` for the `api` service so leads/tracks persist across blue/green cutovers.
- Ensures `deploy.sh` and `scripts/validate_local.sh` create `app_data`.
- Adds CI “volume-smoke” job to verify `app_data` exists and is mounted at `/data` in the API container when a blue stack is up.
- Updates README and Release docs with prerequisites and inspection commands.

2) Testing Instructions
- Pytest/lint:
  - `pip install -r requirements-dev.txt`
  - `make verify` (or `make lint && make test`)
- Local blue stack smoke:
  - `docker network create edge-net && docker volume create edge_caddy_data && docker volume create app_data`
  - `./deploy.sh blue` (or `scripts/validate_local.sh blue`)
  - Verify API: `curl -s http://localhost/api/health`
  - Submit a lead: `curl -s http://localhost/api/leads -X POST -H 'content-type: application/json' -d '{"name":"Jane","email":"jane@example.com"}'`
  - Inspect data:
    - `docker compose -p loancalc-blue exec api sh -lc 'ls -lah ${PERSIST_DIR:-/data}'`
    - `docker compose -p loancalc-blue exec api sh -lc 'cat ${PERSIST_DIR:-/data}/leads.json || echo no leads.json'`
- Green cutover check:
  - `./deploy.sh green`
  - Submit a second lead; confirm both appear from either color (shared `app_data`).
- CI:
  - Confirm the “volume-smoke” job passes and validates `app_data` mount.

3) New Env Vars
- None. No changes to `.env.example`.

4) Docs Impact
- Updated `README.md` (persistence + inspection + CI note) and `RELEASE_PROCESS.md` (one-time creation of `app_data`). Docs updated.

5) Rollback Plan
- Automatic: `deploy.sh` reverts edge to the previous color if live health check fails during cutover.
- Manual rollback by git ref:
  - `scripts/rollback_to.sh <git-ref> --build --yes`
  - Example: `scripts/rollback_to.sh v0.1.0 --build --yes`
- Switch traffic back (no code change): `./deploy.sh blue` or `./deploy.sh green`

6) Validation
- After deploy (`./deploy.sh blue` then `./deploy.sh green`):
  - `curl -s http://localhost/api/health`
  - Submit a lead on each color; verify both in `/data/leads.json` from either color.
- CI volume smoke passes.

CI Evidence Link
- Paste Actions run URL after push:
  - CI: [Link to “CI / volume-smoke” job run](PASTE_LINK_HERE)

Reviewer Checklist
- Branch/name: `infra/persist-shared-app-data-blue-green`
- Commits: Conventional Commits (`infra:`, `docs:`, `ci:`)
- Scope: Single logical infra change; no app logic mixed
- Secrets: None added; no real `.env`; placeholders intact
- Env separation: Dev/staging/prod behavior preserved; no prod secrets in dev
- Determinism: No dependency changes
- Lint/tests: `make lint` and pytest pass in CI
- CI: Build, smoke, and new `volume-smoke` job pass (verifies `/data` ←→ `app_data`)
- Caddy: No Caddyfile changes; `make lint-caddy` still passes
- Blue/Green: `deploy.sh` creates `app_data`; rollback documented and unchanged
- Docs: `README.md` and `RELEASE_PROCESS.md` updated with persistence + inspection
- curl examples: Included for leads and health

Reviewer Notes
- Compose declares `app_data` as an external volume; first-run creation is handled by `deploy.sh`, `scripts/validate_local.sh`, and the CI job step. This keeps existing stacks backward compatible while ensuring fresh environments don’t fail on missing volumes.
- This change is infra-only and CI; APIs/behavior unchanged.
