### PR TITLE
fix(deploy): load .env and robust live check; docs: add shutdown inactive color steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ This project supports blue‑green deployment to minimize downtime. See [Release
   - Deploy blue: `./deploy.sh blue`
   - Validate prod: `make validate-prod`
   - Switch to green: `./deploy.sh green`
+  - Shut down inactive color:
+    - If live is green: `docker compose -p loancalc-blue down --remove-orphans`
+    - If live is blue: `docker compose -p loancalc-green down --remove-orphans`
+
+Notes:
+
+- `deploy.sh` reads `.env` for `APEX_HOST`/`WWW_HOST`/`DOMAIN`. For live verification it prefers `APEX_HOST`, then `DOMAIN`, and falls back to `localhost` in dev.
 
 - Local validation:
 


### PR DESCRIPTION
fix(deploy): load .env and robust live check; docs: add shutdown inactive color steps

1) Summary
- Fixes deploy failure when `DOMAIN` was unset by safely loading `.env` and preferring `APEX_HOST` (fall back to `DOMAIN`, else `localhost`) for live verification.
- Creates shared `app_data` volume if missing (aligns with blue/green shared persistence).
- Updates README with explicit commands to shut down the inactive color stack.

2) Testing Instructions
- Lint/pytest:
  - `pip install -r requirements-dev.txt`
  - `make lint && pytest -q`
- Local smoke:
  - `cp .env.example .env` and set `APEX_HOST=localhost` (or leave blank to see `localhost` fallback).
  - `./deploy.sh blue` then `./deploy.sh green` (verifies health over `http://localhost`).
- Prod:
  - Ensure `.env` on server contains `APEX_HOST`/`WWW_HOST` and other required vars.
  - Run `./deploy.sh green`; script verifies live domain and rolls back on failure.

3) New Env Vars
- None. Uses existing `APEX_HOST`/`WWW_HOST`/`DOMAIN`.

4) Docs Impact
- README updated with shutdown instructions and note on `.env` usage for live check.

5) Validation
- `make validate-prod` continues to validate apex/www redirects and API health.
- Live domain check in `deploy.sh` now works when `DOMAIN` is unset, using `APEX_HOST`.

Reviewer Checklist
- Branch/name: `fix/deploy-live-check-and-docs`
- Commits: Conventional Commits (`fix:` and `docs:`)
- Scope: Single logical change (deploy robustness + docs)
- Lint/tests: Passing
- CI: Should remain green
- Docs: Updated README; no secrets added
