### PR TITLE
feat: add amortization chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Jump-start your next ride with a fast, responsive vehicle loan payment calculato
 - ⚡️ **Instant calculator**: monthly payment, amount financed, total cost, total interest.
 - 📊 **Cost breakdown chart**: flat pie chart sized between 200–260px with generous side and canvas padding, highlighting principal vs interest; tooltips float outside each slice and the caret points back at the chart without getting cut off, with the legend beside it.
 - 🎰 **Rolling digits**: payment amounts animate with fast, smooth scrolling numbers.
+- 🗓️ **Amortization schedule**: API-driven monthly breakdown with rounding-safe totals, collapsible pagination for long terms, and responsive formatting for small screens.
 - 🚘 **Presets**: Auto, RV, Motorcycle, Jet Ski.
 - 👨‍⚖️ **Lead capture**: name/email/phone validated and persisted (+ affiliate/UTM captured automatically).
 - 🤝 **Affiliate tracking**: records click metadata; passthrough to form.
@@ -53,6 +54,14 @@ Base URL in dev: `http://localhost`
   ```bash
   curl -s http://localhost/api/quote -X POST -H 'content-type: application/json' \
     -d '{"vehicle_price":35000,"down_payment":3000,"apr":6.9,"term_months":60,"tax_rate":0.095,"fees":495,"trade_in_value":0}'
+  ```
+
+  The response now includes a `schedule` array with one entry per month:
+
+  ```bash
+  curl -s http://localhost/api/quote -X POST -H 'content-type: application/json' \
+    -d '{"vehicle_price":35000,"down_payment":3000,"apr":6.9,"term_months":60,"tax_rate":0.095,"fees":495,"trade_in_value":0}' \
+    | jq '.schedule[:3]'
   ```
 
 - Leads (POST JSON):

--- a/docs/next/API_SPEC.md
+++ b/docs/next/API_SPEC.md
@@ -31,20 +31,43 @@ Response:
 
 ```json
 {
-  "ok": true,
-  "data": {
-    "monthly_payment": 691.23,
-    "amount_financed": 32000.00,
-    "total_interest": 9153.80,
-    "total_cost": 44153.80
-  }
+  "amount_financed": 35820.0,
+  "monthly_payment": 707.59,
+  "total_interest": 6635.43,
+  "total_cost": 42455.43,
+  "schedule": [
+    {
+      "month": 1,
+      "payment": 707.59,
+      "principal": 501.62,
+      "interest": 205.97,
+      "balance": 35318.38
+    },
+    {
+      "month": 2,
+      "payment": 707.59,
+      "principal": 504.51,
+      "interest": 203.08,
+      "balance": 34813.87
+    },
+    {
+      "month": 60,
+      "payment": 707.62,
+      "principal": 703.57,
+      "interest": 4.05,
+      "balance": 0.0
+    }
+  ]
 }
 ```
 
+- `schedule` contains one entry per month with payments rounded to cents. The final row absorbs any rounding drift so the balance closes at `$0.00`.
+
 Validation:
 
-- `vehicle_price > 0`, `term_months in [6..120]`, `apr in [0..100)`, rates as decimals (e.g., 9.5% => 9.5).
-- Optional fields default to 0 if omitted.
+- `vehicle_price > 0`, `term_months > 0`, `apr >= 0`, and amounts may be passed as whole numbers or decimals (`9.5` for 9.5%).
+- `down_payment`, `fees`, `tax_rate`, and `trade_in_value` default to `0` when omitted.
+- Zero-APR loans are supported; `interest` will be `0.0` for every row.
 
 ## POST /api/leads
 

--- a/docs/next/ROADMAP.md
+++ b/docs/next/ROADMAP.md
@@ -2,10 +2,12 @@
 
 ## Near Term (0-6 weeks)
 
-- Postgres migration
-- Amortization schedule
-- CSV export + minimal analytics
-- First affiliate integration and campaign
+| Ticket                                   | Status      | Notes                                                              |
+| ---------------------------------------- | ----------- | ------------------------------------------------------------------ |
+| Postgres migration                       | In Progress | Kickoff: planning schema and migration path from JSON to Postgres. |
+| Amortization schedule                    | In Review   | API and UI deliver the monthly schedule; rounding QA underway.     |
+| CSV export + minimal analytics           | Todo        | Blocked on Postgres storage to land.                               |
+| First affiliate integration and campaign | Todo        | Depends on analytics + lead tracking readiness.                    |
 
 ## Mid Term (6-12 weeks)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,12 +27,13 @@ def test_integration_quote(client_and_dir):
     }
     resp = client.post("/api/quote", json=payload)
     assert resp.status_code == 200
-    assert resp.json() == {
-        "amount_financed": 19900.0,
-        "monthly_payment": 357.58,
-        "total_interest": 1554.62,
-        "total_cost": 21454.62,
-    }
+    body = resp.json()
+    assert body["amount_financed"] == 19900.0
+    assert body["monthly_payment"] == 357.58
+    assert body["total_interest"] == 1554.61
+    assert body["total_cost"] == 21454.61
+    assert isinstance(body["schedule"], list)
+    assert len(body["schedule"]) == payload["term_months"]
 
 
 def test_integration_lead_persistence(client_and_dir):

--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -20,8 +20,26 @@ def test_quote_basic():
     resp = quote(req)
     assert resp.amount_financed == 19900.0
     assert resp.monthly_payment == 357.58
-    assert resp.total_interest == 1554.62
-    assert resp.total_cost == 21454.62
+    assert resp.total_interest == 1554.61
+    assert resp.total_cost == 21454.61
+
+    assert len(resp.schedule) == req.term_months
+    first = resp.schedule[0]
+    assert first.month == 1
+    assert first.payment == resp.monthly_payment
+    assert first.principal == pytest.approx(307.83)
+    assert first.interest == pytest.approx(49.75)
+    assert first.balance == pytest.approx(19592.17)
+
+    last = resp.schedule[-1]
+    assert last.month == req.term_months
+    assert last.balance == pytest.approx(0.0, abs=0.01)
+
+    total_principal = round(sum(row.principal for row in resp.schedule), 2)
+    total_interest = round(sum(row.interest for row in resp.schedule), 2)
+    assert total_principal == resp.amount_financed
+    assert total_interest == resp.total_interest
+    assert round(total_principal + total_interest, 2) == resp.total_cost
 
 
 def test_quote_zero_apr():
@@ -39,6 +57,10 @@ def test_quote_zero_apr():
     assert resp.monthly_payment == 1000.0
     assert resp.total_interest == 0.0
     assert resp.total_cost == 10000.0
+
+    assert len(resp.schedule) == req.term_months
+    assert all(row.interest == 0.0 for row in resp.schedule)
+    assert resp.schedule[-1].balance == pytest.approx(0.0, abs=0.01)
 
 
 def test_quote_zero_term_validation():
@@ -69,6 +91,8 @@ def test_quote_trade_in_exceeds_price():
     assert resp.monthly_payment == 0
     assert resp.total_interest == 0
     assert resp.total_cost == 0
+    assert len(resp.schedule) == req.term_months
+    assert all(row.payment == 0 for row in resp.schedule)
 
 
 def test_quote_negative_apr_validation():
@@ -102,12 +126,25 @@ def test_quote_endpoint_basic():
     }
     resp = client.post("/api/quote", json=payload)
     assert resp.status_code == 200
-    assert resp.json() == {
-        "amount_financed": 19900.0,
-        "monthly_payment": 357.58,
-        "total_interest": 1554.62,
-        "total_cost": 21454.62,
-    }
+    data = resp.json()
+    assert data["amount_financed"] == 19900.0
+    assert data["monthly_payment"] == 357.58
+    assert data["total_interest"] == 1554.61
+    assert data["total_cost"] == 21454.61
+    assert isinstance(data["schedule"], list)
+    assert len(data["schedule"]) == payload["term_months"]
+    first = data["schedule"][0]
+    assert first["month"] == 1
+    assert first["payment"] == data["monthly_payment"]
+    assert first["principal"] == pytest.approx(307.83)
+    assert first["interest"] == pytest.approx(49.75)
+    last = data["schedule"][-1]
+    assert last["month"] == payload["term_months"]
+    assert last["balance"] == pytest.approx(0.0, abs=0.01)
+    principal_sum = round(sum(row["principal"] for row in data["schedule"]), 2)
+    interest_sum = round(sum(row["interest"] for row in data["schedule"]), 2)
+    assert principal_sum == data["amount_financed"]
+    assert interest_sum == data["total_interest"]
 
 
 def test_quote_endpoint_validation_error():

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -153,9 +153,39 @@
         </div>
         
         <div class="expandable-content" id="amortization-content">
-          <p style="text-align: center; color: var(--text-secondary); padding: 20px;">
-            Detailed monthly breakdown coming soon...
-          </p>
+          <div class="amortization-wrapper">
+            <div class="amortization-status" id="amortization-status" role="status" aria-live="polite"></div>
+            <div class="amortization-visual" aria-hidden="false">
+              <div class="amortization-visual-header">
+                <h4>Balance timeline</h4>
+                <p>See how the remaining balance shrinks and principal accumulates each month.</p>
+              </div>
+              <div class="amortization-chart" role="figure" aria-labelledby="amortization-chart-title">
+                <h5 id="amortization-chart-title" class="sr-only">Amortization chart</h5>
+                <canvas id="amortization-chart" aria-label="Line chart of remaining balance and cumulative principal paid over the loan term"></canvas>
+              </div>
+            </div>
+            <div class="amortization-table-container" id="amortization-table-container">
+              <table class="amortization-table" id="amortization-table">
+                <caption class="sr-only">Monthly amortization schedule</caption>
+                <thead>
+                  <tr>
+                    <th scope="col">Month</th>
+                    <th scope="col">Payment</th>
+                    <th scope="col">Principal</th>
+                    <th scope="col">Interest</th>
+                    <th scope="col">Balance</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+            <div class="amortization-controls">
+              <button type="button" class="amortization-toggle" id="amortization-view-toggle" hidden>
+                Show full schedule
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </main>

--- a/web/dist/style.css
+++ b/web/dist/style.css
@@ -496,6 +496,182 @@ body {
   text-decoration: underline;
 }
 
+.amortization-wrapper {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.amortization-visual {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.amortization-visual-header h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.amortization-visual-header p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.amortization-chart {
+  position: relative;
+  width: 100%;
+  height: 260px;
+}
+
+.amortization-chart canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.amortization-chart canvas.is-empty {
+  opacity: 0;
+}
+
+.amortization-status {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  text-align: left;
+  min-height: 1.2em;
+}
+
+.amortization-status.loading {
+  color: var(--text-secondary);
+}
+
+.amortization-status.error {
+  color: #dc2626;
+}
+
+.amortization-table-container {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-primary);
+  overflow: hidden;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.amortization-table-container.is-empty {
+  display: none;
+}
+
+.amortization-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 480px;
+}
+
+.amortization-table thead {
+  background: var(--bg-secondary);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.amortization-table th,
+.amortization-table td {
+  padding: 12px 16px;
+  text-align: right;
+  font-size: 0.9rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.amortization-table th:first-child,
+.amortization-table td:first-child {
+  text-align: left;
+}
+
+.amortization-table tbody tr:nth-child(odd) {
+  background: rgba(0, 0, 0, 0.02);
+}
+
+.amortization-controls {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.amortization-toggle {
+  border: 1px solid var(--border);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border-radius: var(--radius);
+  padding: 8px 16px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.amortization-toggle:hover {
+  border-color: var(--gold);
+  color: var(--gold-dark);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .amortization-table {
+    min-width: 100%;
+  }
+
+  .amortization-table thead {
+    display: none;
+  }
+
+  .amortization-table tbody tr {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .amortization-table tbody tr:nth-child(odd) {
+    background: transparent;
+  }
+
+  .amortization-table td {
+    text-align: left;
+    border: none;
+    padding: 0;
+    font-size: 0.9rem;
+    position: relative;
+  }
+
+  .amortization-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 4px;
+  }
+}
+
 .footer {
   text-align: center;
   margin-top: 40px;


### PR DESCRIPTION
## Summary
- add an amortization line chart that visualizes the monthly balance and cumulative principal alongside the table
- hook the schedule loading pipeline to drive the chart state during success, loading, and error scenarios
- style the new balance timeline section for accessibility and responsive layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ead84247fc83329bc2689ebfb82e12